### PR TITLE
[20] Fix s3

### DIFF
--- a/discovery_utils/utils/s3.py
+++ b/discovery_utils/utils/s3.py
@@ -26,9 +26,12 @@ AWS_SECRET_KEY = os.getenv("AWS_SECRET_KEY")
 
 
 def s3_client(aws_access_key_id: str = AWS_ACCESS_KEY, aws_secret_access_key: str = AWS_SECRET_KEY) -> BaseClient:
-    """Initialize S3 client"""
-    S3 = boto3.client("s3", aws_access_key_id, aws_secret_access_key)
-    return S3
+    """Initialize and return an S3 client"""
+    return boto3.client(
+        "s3",
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+    )
 
 
 def _get_bucket_filenames(bucket_name: str, dir_name: str = "") -> List[str]:

--- a/discovery_utils/utils/s3.py
+++ b/discovery_utils/utils/s3.py
@@ -92,7 +92,7 @@ def _fileobj_to_df(fileobj: io.BytesIO, path_from: str, **kwargs) -> pd.DataFram
         return pd.read_parquet(fileobj, **kwargs)
 
 
-def _fileobj_to_dict(fileobj: io.BytesIO, path_from: str, **kwargs) -> dict:
+def _fileobj_to_dict(fileobj: io.BytesIO, **kwargs) -> dict:
     """Convert bytes file object into dictionary.
 
     Args:


### PR DESCRIPTION
Closes #20.

`aws_access_key_id` and `aws_secret_access_key` in `boto3.client` have been updated to be keyword arguments for function `utils.s3.s3_client`

`utils.s3._download_obj` updated so `kwargs_boto` and `kwards_reading` are empty dicts if none are given in the function inputs

Removed unused import from `_fileobj_to_dict`

