### PR TITLE
[15] SVC training and inference

### DIFF
--- a/discovery_utils/getters/horizon_scout.py
+++ b/discovery_utils/getters/horizon_scout.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pandas as pd
 
+from sklearn.svm import SVC
+
 from discovery_utils.horizon_scout.make_training_data import DataPaths
 from discovery_utils.utils import s3
 
@@ -44,3 +46,21 @@ def get_training_data(mission: str) -> pd.DataFrame:
         training_data["embedding"] = training_data["embedding"].apply(convert_to_array)
 
     return training_data
+
+
+def get_svc_model(mission: str, svc_model_filename: str) -> SVC:
+    """Load SCV from S3
+
+    Args:
+        mission (str): Nesta mission ('AHL', 'AFS' or 'ASF')
+        model_filename (str): Filename on S3 e.g. 'AHL_svc_0.882_20240517-1602.pkl'
+
+    Returns:
+        SVC: Support Vector Classifier for specified mission and filename
+    """
+    return s3._download_obj(
+        s3_client=client,
+        bucket=s3.BUCKET_NAME_RAW,
+        path_from=f"models/horizon_scout/{mission}/{svc_model_filename}",
+        download_as=None,
+    )

--- a/discovery_utils/horizon_scout/inference_svc.py
+++ b/discovery_utils/horizon_scout/inference_svc.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+
+from discovery_utils.getters.horizon_scout import get_svc_model
+from discovery_utils.utils.embeddings import add_embeddings
+
+
+def svc_add_predictions(
+    mission: str,
+    svc_model_filename: str,
+    df: pd.DataFrame,
+    text_col: str = "text",
+    embedding_col: str = None,
+    predictions_col: str = "predictions",
+) -> pd.DataFrame:
+    """Use SVC to add predictions to input DataFrame.
+
+    Args:
+        mission (str): Nesta mission ('AHL', 'AFS' or 'ASF').
+        model_filename (str): Filename on S3 e.g. 'AHL_svc_0.882_20240517-1602.pkl'.
+        df (pd.DataFrame): Input DataFrame containing the text data.
+        text_col (str): Column name for the text in the DataFrame.
+        embedding_col (str): Column name for the embeddings in the DataFrame.
+        prediction_col (str): Column name to assign to the SVC predictions.
+
+    Returns:
+        pd.DataFrame: The original DataFrame with four additional columns:
+            'embedding', 'embedding_model', "predictions", "prediction_model".
+    """
+    svc = get_svc_model(mission, svc_model_filename)
+    df = df.dropna(subset=text_col)
+    if not embedding_col:
+        df = add_embeddings(df, text_col=text_col)
+        X = np.vstack(df.embedding.values)
+    else:
+        X = np.vstack(df[embedding_col].values)
+    df[predictions_col] = svc.predict(X=X)
+    df["prediction_model"] = svc_model_filename
+    return df

--- a/discovery_utils/horizon_scout/train_svc.py
+++ b/discovery_utils/horizon_scout/train_svc.py
@@ -1,0 +1,71 @@
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+from sklearn import svm
+from sklearn.model_selection import GridSearchCV
+
+from discovery_utils import logging
+from discovery_utils.getters.horizon_scout import get_training_data
+from discovery_utils.horizon_scout.utils import get_current_datetime
+from discovery_utils.utils import s3
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+client = s3.s3_client()
+
+
+def make_x_y(train_dataset: pd.DataFrame) -> Tuple[np.array, np.array]:
+    """
+    Create X (text embeddings) and y (target) arrays.
+
+    Args:
+        train_dataset (pd.DataFrame): The training dataset containing features and target.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: A tuple containing two arrays: (X, y).
+    """
+    X = np.vstack(train_dataset.embedding.values)
+    y = train_dataset.relevant.values
+    return (X, y)
+
+
+MISSION = "AHL"
+
+
+if __name__ == "__main__":
+    # Make X and y for each mission
+    X, y = make_x_y(get_training_data(MISSION))
+
+    param_grid = [
+        {
+            "C": [1.1, 1.2, 1.3],
+            "kernel": ["poly"],
+            "degree": [3],
+            "gamma": ["scale"],
+            "coef0": [0.0000001, 0.000001, 0.000002],
+        }
+    ]
+
+    # Carry out Cross Validation Grid Search to find best parameters
+    svc = svm.SVC()
+    grid_search = GridSearchCV(svc, param_grid, cv=5, verbose=3)
+    grid_search.fit(X, y)
+
+    best_score = round(grid_search.best_score_, 3)
+
+    logging.info("Best parameters found: %s", grid_search.best_params_)
+    logging.info("Best accuracy: %s", best_score)
+
+    # Calculate datetime
+    current_datetime = get_current_datetime()
+
+    # Save best model to s3
+    s3.upload_obj(
+        grid_search.best_estimator_,
+        s3.BUCKET_NAME_RAW,
+        f"models/horizon_scout/{MISSION}/{MISSION}_svc_{best_score}_{current_datetime}.pkl",
+    )

--- a/discovery_utils/horizon_scout/utils.py
+++ b/discovery_utils/horizon_scout/utils.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+import numpy as np
+
+from sklearn.metrics import accuracy_score
+from sklearn.metrics import confusion_matrix
+from sklearn.metrics import precision_score
+from sklearn.metrics import recall_score
+
+from discovery_utils import logging
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def display_confusion_matrix(actual: np.array, predictions: np.array) -> None:
+    """
+    Log the confusion matrix along with precision, recall, and accuracy metrics.
+
+    Args:
+        actual (np.ndarray): Array of actual target values.
+        predictions (np.ndarray): Array of predicted target values.
+    """
+    cm = confusion_matrix(actual, predictions)
+    classes = ["Neg", "Pos"]
+
+    logging.info("            Predicted:")
+    logging.info("            | %s | %s |", classes[0], classes[1])
+    logging.info("-----------------------------")
+    for i, row in enumerate(cm):
+        logging.info("Actual %s | %4d | %4d |", classes[i], row[0], row[1])
+
+    precision = precision_score(actual, predictions, average="binary")
+    recall = recall_score(actual, predictions, average="binary")
+    accuracy = accuracy_score(actual, predictions)
+
+    logging.info("Precision: %.3f", precision)
+    logging.info("Recall: %.3f", recall)
+    logging.info("Accuracy: %.3f", accuracy)
+
+
+def get_current_datetime() -> str:
+    """Get the current date and time in the format yyyymmdd-hhmmss."""
+    return datetime.now().strftime("%Y%m%d-%H%M")

--- a/discovery_utils/utils/embeddings.py
+++ b/discovery_utils/utils/embeddings.py
@@ -15,10 +15,10 @@ def add_embeddings(df: pd.DataFrame, text_col: str = "text", model_name: str = "
         model_name (str): Name of the sentence transformer model to use.
 
     Returns:
-        pd.DataFrame: The original DataFrame with two new columns: 'embedding' and 'model_name'.
+        pd.DataFrame: The original DataFrame with two new columns: 'embedding' and 'embedding_model'.
     """
     model = SentenceTransformer(model_name)
     embeddings = model.encode(df[text_col].tolist(), show_progress_bar=True)
     df["embedding"] = list(embeddings)
-    df["model_name"] = model_name
+    df["embedding_model"] = model_name
     return df

--- a/discovery_utils/utils/s3.py
+++ b/discovery_utils/utils/s3.py
@@ -422,9 +422,7 @@ def upload_obj(
         obj = _np_array_to_fileobj(obj, path_to, **kwargs_writing)
     else:
         obj = _unsupp_data_to_fileobj(obj, path_to, **kwargs_writing)
-        warnings.warn(
-            "Data uploaded as pickle. Please consider other accessible " "file types among the supported ones."
-        )
+        warnings.warn("Data uploaded as pickle. Please consider other accessible file types among the supported ones.")
 
     s3 = boto3.client("s3")
     s3.upload_fileobj(obj, bucket, path_to, **kwargs_boto)

--- a/notebooks/train_classifiers.ipynb
+++ b/notebooks/train_classifiers.ipynb
@@ -17,7 +17,12 @@
    ],
    "source": [
     "from discovery_utils.getters.horizon_scout import get_training_data\n",
+<<<<<<< HEAD
     "from discovery_utils.enrichment.crunchbase import _enrich_keyword_labels"
+=======
+    "from discovery_utils.enrichment.crunchbase import _enrich_keyword_labels\n",
+    "from discovery_utils.horizon_scout.utils import display_confusion_matrix"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -30,7 +35,10 @@
     "import pandas as pd\n",
     "from typing import Tuple\n",
     "import numpy as np\n",
+<<<<<<< HEAD
     "from sklearn.metrics import confusion_matrix, precision_score, recall_score, accuracy_score\n",
+=======
+>>>>>>> 0edcda0 (Training and inference for SVC)
     "from sklearn.svm import SVC\n",
     "from sklearn.linear_model import LogisticRegression\n",
     "from sklearn.neighbors import KNeighborsClassifier"
@@ -90,6 +98,7 @@
     "    val_X = np.vstack(val_dataset.embedding.values)\n",
     "    val_y = val_dataset.relevant.values\n",
     "    return (train_X, train_y, val_X, val_y)\n",
+<<<<<<< HEAD
     "\n",
     "    \n",
     "def print_confusion_matrix(actual: np.array, predictions: np.array):\n",
@@ -118,6 +127,8 @@
     "    print(f\"Precision: {precision:.3f}\")\n",
     "    print(f\"Recall: {recall:.3f}\")\n",
     "    print(f\"Accuracy: {accuracy:.3f}\")\n",
+=======
+>>>>>>> 0edcda0 (Training and inference for SVC)
     "    \n",
     "    \n",
     "def classify_by_keywords(dataset: pd.DataFrame, mission: str) -> pd.DataFrame:\n",
@@ -159,6 +170,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -171,13 +183,30 @@
       "Precision: 0.989\n",
       "Recall: 0.687\n",
       "Accuracy: 0.835\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg | 1114 |   15 |\n",
+      "INFO:root:Actual Pos |  821 |  209 |\n",
+      "INFO:root:Precision: 0.933\n",
+      "INFO:root:Recall: 0.203\n",
+      "INFO:root:Accuracy: 0.613\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
    "source": [
     "# Keyword classifier AHL\n",
     "ahl_val_with_preds = classify_by_keywords(ahl_val, \"AHL\")\n",
+<<<<<<< HEAD
     "print_confusion_matrix(ahl_val_with_preds.relevant.values, ahl_val_with_preds.prediction.values)"
+=======
+    "display_confusion_matrix(ahl_val_with_preds.relevant.values, ahl_val_with_preds.prediction.values)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -187,6 +216,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -199,6 +229,19 @@
       "Precision: 0.950\n",
       "Recall: 0.928\n",
       "Accuracy: 0.938\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg | 1012 |  117 |\n",
+      "INFO:root:Actual Pos |   96 |  934 |\n",
+      "INFO:root:Precision: 0.889\n",
+      "INFO:root:Recall: 0.907\n",
+      "INFO:root:Accuracy: 0.901\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -207,7 +250,11 @@
     "linear_svm_ahl_classifier = SVC(kernel='linear', C=2)\n",
     "linear_svm_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
     "linear_svm_ahl_preds = linear_svm_ahl_classifier.predict(ahl_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(ahl_val_y, linear_svm_ahl_preds)"
+=======
+    "display_confusion_matrix(ahl_val_y, linear_svm_ahl_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -217,6 +264,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -229,6 +277,19 @@
       "Precision: 0.973\n",
       "Recall: 0.943\n",
       "Accuracy: 0.957\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg | 1045 |   84 |\n",
+      "INFO:root:Actual Pos |   71 |  959 |\n",
+      "INFO:root:Precision: 0.919\n",
+      "INFO:root:Recall: 0.931\n",
+      "INFO:root:Accuracy: 0.928\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -237,7 +298,11 @@
     "poly_svm_ahl_classifier = SVC(kernel='poly', degree=4, C=0.3, gamma='scale', coef0=0.5)\n",
     "poly_svm_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
     "poly_svm_ahl_preds = poly_svm_ahl_classifier.predict(ahl_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(ahl_val_y, poly_svm_ahl_preds)"
+=======
+    "display_confusion_matrix(ahl_val_y, poly_svm_ahl_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -247,6 +312,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -259,6 +325,19 @@
       "Precision: 0.957\n",
       "Recall: 0.917\n",
       "Accuracy: 0.936\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg | 1016 |  113 |\n",
+      "INFO:root:Actual Pos |   94 |  936 |\n",
+      "INFO:root:Precision: 0.892\n",
+      "INFO:root:Recall: 0.909\n",
+      "INFO:root:Accuracy: 0.904\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -267,7 +346,11 @@
     "lr_ahl_classifier = LogisticRegression(solver='lbfgs', max_iter=50, C=1)\n",
     "lr_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
     "lr_ahl_preds = lr_ahl_classifier.predict(ahl_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(ahl_val_y, lr_ahl_preds)"
+=======
+    "display_confusion_matrix(ahl_val_y, lr_ahl_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -277,6 +360,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -289,6 +373,19 @@
       "Precision: 0.931\n",
       "Recall: 0.962\n",
       "Accuracy: 0.944\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  987 |  142 |\n",
+      "INFO:root:Actual Pos |   61 |  969 |\n",
+      "INFO:root:Precision: 0.872\n",
+      "INFO:root:Recall: 0.941\n",
+      "INFO:root:Accuracy: 0.906\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -297,7 +394,11 @@
     "knn_ahl_classifier = KNeighborsClassifier(n_neighbors=4)\n",
     "knn_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
     "knn_ahl_preds = knn_ahl_classifier.predict(ahl_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(ahl_val_y, knn_ahl_preds)"
+=======
+    "display_confusion_matrix(ahl_val_y, knn_ahl_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -320,6 +421,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -332,13 +434,30 @@
       "Precision: 0.953\n",
       "Recall: 0.504\n",
       "Accuracy: 0.734\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  232 |    9 |\n",
+      "INFO:root:Actual Pos |  125 |  124 |\n",
+      "INFO:root:Precision: 0.932\n",
+      "INFO:root:Recall: 0.498\n",
+      "INFO:root:Accuracy: 0.727\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
    "source": [
     "# Keyword classifier ASF\n",
     "asf_val_with_preds = classify_by_keywords(asf_val, \"ASF\")\n",
+<<<<<<< HEAD
     "print_confusion_matrix(asf_val_with_preds.relevant.values, asf_val_with_preds.prediction.values)"
+=======
+    "display_confusion_matrix(asf_val_with_preds.relevant.values, asf_val_with_preds.prediction.values)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -348,6 +467,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -360,6 +480,19 @@
       "Precision: 0.930\n",
       "Recall: 0.884\n",
       "Accuracy: 0.907\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  224 |   17 |\n",
+      "INFO:root:Actual Pos |   47 |  202 |\n",
+      "INFO:root:Precision: 0.922\n",
+      "INFO:root:Recall: 0.811\n",
+      "INFO:root:Accuracy: 0.869\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -368,7 +501,11 @@
     "linear_svm_asf_classifier = SVC(kernel='linear', C=0.1)\n",
     "linear_svm_asf_classifier.fit(asf_train_X, asf_train_y)\n",
     "linear_svm_asf_preds = linear_svm_asf_classifier.predict(asf_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(asf_val_y, linear_svm_asf_preds)"
+=======
+    "display_confusion_matrix(asf_val_y, linear_svm_asf_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -378,6 +515,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -390,6 +528,19 @@
       "Precision: 0.948\n",
       "Recall: 0.905\n",
       "Accuracy: 0.926\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  225 |   16 |\n",
+      "INFO:root:Actual Pos |   33 |  216 |\n",
+      "INFO:root:Precision: 0.931\n",
+      "INFO:root:Recall: 0.867\n",
+      "INFO:root:Accuracy: 0.900\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -398,7 +549,11 @@
     "poly_svm_asf_classifier = SVC(kernel='poly', degree=4, C=0.3, gamma='scale', coef0=0.5)\n",
     "poly_svm_asf_classifier.fit(asf_train_X, asf_train_y)\n",
     "poly_svm_asf_preds = poly_svm_asf_classifier.predict(asf_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(asf_val_y, poly_svm_asf_preds)"
+=======
+    "display_confusion_matrix(asf_val_y, poly_svm_asf_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -408,6 +563,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -420,6 +576,19 @@
       "Precision: 0.947\n",
       "Recall: 0.888\n",
       "Accuracy: 0.918\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  222 |   19 |\n",
+      "INFO:root:Actual Pos |   39 |  210 |\n",
+      "INFO:root:Precision: 0.917\n",
+      "INFO:root:Recall: 0.843\n",
+      "INFO:root:Accuracy: 0.882\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -428,7 +597,11 @@
     "lr_asf_classifier = LogisticRegression(solver='newton-cg', penalty=\"l2\", C=3)\n",
     "lr_asf_classifier.fit(asf_train_X, asf_train_y)\n",
     "lr_asf_preds = lr_asf_classifier.predict(asf_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(asf_val_y, lr_asf_preds)"
+=======
+    "display_confusion_matrix(asf_val_y, lr_asf_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -438,6 +611,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -450,6 +624,19 @@
       "Precision: 0.895\n",
       "Recall: 0.955\n",
       "Accuracy: 0.920\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  205 |   36 |\n",
+      "INFO:root:Actual Pos |   21 |  228 |\n",
+      "INFO:root:Precision: 0.864\n",
+      "INFO:root:Recall: 0.916\n",
+      "INFO:root:Accuracy: 0.884\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -458,7 +645,11 @@
     "knn_asf_classifier = KNeighborsClassifier(n_neighbors=10)\n",
     "knn_asf_classifier.fit(asf_train_X, asf_train_y)\n",
     "knn_asf_preds = knn_asf_classifier.predict(asf_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(asf_val_y, knn_asf_preds)"
+=======
+    "display_confusion_matrix(asf_val_y, knn_asf_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -481,6 +672,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -493,13 +685,30 @@
       "Precision: 0.933\n",
       "Recall: 0.729\n",
       "Accuracy: 0.834\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  216 |    4 |\n",
+      "INFO:root:Actual Pos |   63 |  176 |\n",
+      "INFO:root:Precision: 0.978\n",
+      "INFO:root:Recall: 0.736\n",
+      "INFO:root:Accuracy: 0.854\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
    "source": [
     "# Keyword classifier AFS\n",
     "afs_val_with_preds = classify_by_keywords(afs_val, \"AFS\")\n",
+<<<<<<< HEAD
     "print_confusion_matrix(afs_val_with_preds.relevant.values, afs_val_with_preds.prediction.values)"
+=======
+    "display_confusion_matrix(afs_val_with_preds.relevant.values, afs_val_with_preds.prediction.values)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -509,6 +718,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -521,6 +731,19 @@
       "Precision: 0.970\n",
       "Recall: 0.974\n",
       "Accuracy: 0.971\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  199 |   21 |\n",
+      "INFO:root:Actual Pos |    9 |  230 |\n",
+      "INFO:root:Precision: 0.916\n",
+      "INFO:root:Recall: 0.962\n",
+      "INFO:root:Accuracy: 0.935\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -529,7 +752,11 @@
     "linear_svm_afs_classifier = SVC(kernel='linear', C=0.1)\n",
     "linear_svm_afs_classifier.fit(afs_train_X, afs_train_y)\n",
     "linear_svm_afs_preds = linear_svm_afs_classifier.predict(afs_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(afs_val_y, linear_svm_afs_preds)"
+=======
+    "display_confusion_matrix(afs_val_y, linear_svm_afs_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -539,6 +766,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -551,6 +779,19 @@
       "Precision: 0.974\n",
       "Recall: 0.969\n",
       "Accuracy: 0.971\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  201 |   19 |\n",
+      "INFO:root:Actual Pos |   14 |  225 |\n",
+      "INFO:root:Precision: 0.922\n",
+      "INFO:root:Recall: 0.941\n",
+      "INFO:root:Accuracy: 0.928\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -559,7 +800,11 @@
     "poly_svm_afs_classifier = SVC(kernel='poly', degree=4, C=0.1, gamma='scale', coef0=0.5)\n",
     "poly_svm_afs_classifier.fit(afs_train_X, afs_train_y)\n",
     "poly_svm_afs_preds = poly_svm_afs_classifier.predict(afs_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(afs_val_y, poly_svm_afs_preds)"
+=======
+    "display_confusion_matrix(afs_val_y, poly_svm_afs_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -569,6 +814,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -581,6 +827,19 @@
       "Precision: 0.974\n",
       "Recall: 0.965\n",
       "Accuracy: 0.969\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  205 |   15 |\n",
+      "INFO:root:Actual Pos |   12 |  227 |\n",
+      "INFO:root:Precision: 0.938\n",
+      "INFO:root:Recall: 0.950\n",
+      "INFO:root:Accuracy: 0.941\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -589,7 +848,11 @@
     "lr_afs_classifier = LogisticRegression(solver='saga', penalty=\"l2\", max_iter=100, C=8)\n",
     "lr_afs_classifier.fit(afs_train_X, afs_train_y)\n",
     "lr_afs_preds = lr_afs_classifier.predict(afs_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(afs_val_y, lr_afs_preds)"
+=======
+    "display_confusion_matrix(afs_val_y, lr_afs_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -599,6 +862,7 @@
    "metadata": {},
    "outputs": [
     {
+<<<<<<< HEAD
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -611,6 +875,19 @@
       "Precision: 0.915\n",
       "Recall: 0.983\n",
       "Accuracy: 0.944\n"
+=======
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:            Predicted:\n",
+      "INFO:root:            | Neg | Pos |\n",
+      "INFO:root:-----------------------------\n",
+      "INFO:root:Actual Neg |  186 |   34 |\n",
+      "INFO:root:Actual Pos |    1 |  238 |\n",
+      "INFO:root:Precision: 0.875\n",
+      "INFO:root:Recall: 0.996\n",
+      "INFO:root:Accuracy: 0.924\n"
+>>>>>>> 0edcda0 (Training and inference for SVC)
      ]
     }
    ],
@@ -619,7 +896,11 @@
     "knn_afs_classifier = KNeighborsClassifier(n_neighbors=5)\n",
     "knn_afs_classifier.fit(afs_train_X, afs_train_y)\n",
     "knn_afs_preds = knn_afs_classifier.predict(afs_val_X)\n",
+<<<<<<< HEAD
     "print_confusion_matrix(afs_val_y, knn_afs_preds)"
+=======
+    "display_confusion_matrix(afs_val_y, knn_afs_preds)"
+>>>>>>> 0edcda0 (Training and inference for SVC)
    ]
   },
   {
@@ -658,7 +939,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
+<<<<<<< HEAD
    "id": "bfe41220",
+=======
+   "id": "500299aa",
+>>>>>>> 0edcda0 (Training and inference for SVC)
    "metadata": {},
    "outputs": [],
    "source": []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ python-dotenv = "^1.0.1"
 nltk = "^3.8.1"
 matplotlib = "^3.8.4"
 sentence-transformers = "^2.7.0"
+seaborn = "^0.13.2"
+datasets = "^2.19.0"
+evaluate = "^0.4.2"
+accelerate = "^0.29.3"
+skypilot = "^0.5.0"
 
 
 [tool.poetry.group.test]


### PR DESCRIPTION
This PR adds:
- `discovery_utils/horizon_scout/inference_svc.py` -- Function to perform mission classification using SVC model.
- `discovery_utils/horizon_scout/train_svc.py` -- Script to train the SVC and find optimal settings using Grid Search Cross Validation. When the training runs are complete, the best performing model is saved to S3.

This PR updates:
- `discovery_utils/horizon_scout/make_training_data.py` -- The script now replaces some of the randomly sampled negative data with specific examples from S3