### PR TITLE
[15] BERT classifier training and inference

### DIFF
--- a/discovery_utils/getters/horizon_scout.py
+++ b/discovery_utils/getters/horizon_scout.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 from sklearn.svm import SVC
-from transformers import pipeline
+from transformers import PreTrainedModel
 
 from discovery_utils.horizon_scout.make_training_data import DataPaths
 from discovery_utils.utils import s3
@@ -67,19 +67,19 @@ def get_svc_model(mission: str, svc_model_filename: str) -> SVC:
     )
 
 
-def get_bert_classifier(mission: str, bert_classifier_filename: str) -> pipeline:
-    """Load BERT classifier from S3
+def get_bert_model(mission: str, bert_model_filename: str) -> PreTrainedModel:
+    """Load BERT model from S3
 
     Args:
         mission (str): Nesta mission ('AHL', 'AFS' or 'ASF')
-        model_filename (str): Filename on S3 e.g. 'AHL_bert_0.965_20240530-2244.pkl'
+        model_filename (str): Filename on S3 e.g. 'AHL_bert_model_0.965_20240530-2244.pkl'
 
     Returns:
-        pipeline: BERT classification pipeline
+        PreTrainedModel: BERT model
     """
     return s3._download_obj(
         s3_client=client,
         bucket=s3.BUCKET_NAME_RAW,
-        path_from=f"models/horizon_scout/{mission}/{bert_classifier_filename}",
+        path_from=f"models/horizon_scout/{mission}/{bert_model_filename}",
         download_as=None,
     )

--- a/discovery_utils/getters/horizon_scout.py
+++ b/discovery_utils/getters/horizon_scout.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 from sklearn.svm import SVC
+from transformers import pipeline
 
 from discovery_utils.horizon_scout.make_training_data import DataPaths
 from discovery_utils.utils import s3
@@ -62,5 +63,23 @@ def get_svc_model(mission: str, svc_model_filename: str) -> SVC:
         s3_client=client,
         bucket=s3.BUCKET_NAME_RAW,
         path_from=f"models/horizon_scout/{mission}/{svc_model_filename}",
+        download_as=None,
+    )
+
+
+def get_bert_classifier(mission: str, bert_classifier_filename: str) -> pipeline:
+    """Load BERT classifier from S3
+
+    Args:
+        mission (str): Nesta mission ('AHL', 'AFS' or 'ASF')
+        model_filename (str): Filename on S3 e.g. 'AHL_bert_0.965_20240530-2244.pkl'
+
+    Returns:
+        pipeline: BERT classification pipeline
+    """
+    return s3._download_obj(
+        s3_client=client,
+        bucket=s3.BUCKET_NAME_RAW,
+        path_from=f"models/horizon_scout/{mission}/{bert_classifier_filename}",
         download_as=None,
     )

--- a/discovery_utils/horizon_scout/README.md
+++ b/discovery_utils/horizon_scout/README.md
@@ -1,10 +1,22 @@
 # Horizon Scout
 
-A collection of scripts and utils relating to the mission classifiers for Horizon Scout project.
+A collection of scripts and utils relating to the mission classifiers for the Horizon Scout project.
+
+## Training data
+
+The raw training data can be found on S3 at `s3://discovery-iss/data/horizon_scout/classifier_training_data_inputs/`. To add more training, update the files here.
+
+To process the data so it can be used for training, run `make_training_data.py`. This will save training data for each mission to `s3://discovery-iss/data/horizon_scout/classifier_training_data_outputs/`.
+
+## BERT training and inference
+
+To train the BERT mission classifiers, run `train_bert.py`. Running this file will save a classifier for each mission to `s3://discovery-iss/models/horizon_scout/`.
+
+To use the BERT mission classifiers for inference, run `inference_bert.py`. Before running check the constants at the top of the file. If `MODE` is set to `"New"`, it will perform inference on only today's new companies. If `MODE` is set to `"Full"`, it will perform inference on the full Crunchbase dataset. Predicted labels are stored in the label store found at `s3://discovery-iss/data/crunchbase/enriched/label_store.csv`.
+
+`train_bert.py` and `inference_bert.py` scripts are intended to be ran using skypilot. To run them via Skypilot, the related YAML files need to be executed. These files can be found at `discovery_utils/horizon_scout/train_bert.yml` and `discovery_utils/horizon_scout/inference_bert.yml`.
 
 ## Skypilot
-
-`train_bert.py` and `inference_bert.py` scripts are intended to be used with skypilot.
 
 Here are some useful example skypilot commands:
 
@@ -15,6 +27,10 @@ sky launch -c g5 discovery_utils/horizon_scout/train_bert.yml
 If `g5` is already launched, use `exec` (this avoids having to run the setup steps) to train the BERT mission classifiers run :
 ```bash
 sky exec g5 discovery_utils/horizon_scout/train_bert.yml
+```
+To launch an instance, name it `g5`, run setup (copy credentials, install poetry) and use the BERT mission classifiers for inference run:
+```bash
+sky launch -c g5 discovery_utils/horizon_scout/inference_bert.yml
 ```
 To ssh to the instance:
 ```bash

--- a/discovery_utils/horizon_scout/README.md
+++ b/discovery_utils/horizon_scout/README.md
@@ -1,0 +1,35 @@
+# Horizon Scout
+
+A collection of scripts and utils relating to the mission classifiers for Horizon Scout project.
+
+## Skypilot
+
+`train_bert.py` and `inference_bert.py` scripts are intended to be used with skypilot.
+
+Here are some useful example skypilot commands:
+
+To launch an instance, name it `g5`, run setup (copy credentials, install poetry) and train the BERT mission classifiers run:
+```bash
+sky launch -c g5 discovery_utils/horizon_scout/train_bert.yml
+```
+If `g5` is already launched, use `exec` (this avoids having to run the setup steps) to train the BERT mission classifiers run :
+```bash
+sky exec g5 discovery_utils/horizon_scout/train_bert.yml
+```
+To ssh to the instance:
+```bash
+ssh g5
+```
+To stop the instance:
+```bash
+sky stop g5
+```
+To terminate the instance:
+```bash
+sky down g5
+```
+To check which instances are running:
+```bash
+sky status
+```
+See the [skypilot documentation](https://skypilot.readthedocs.io/en/latest/docs/index.html) for more information.

--- a/discovery_utils/horizon_scout/inference_bert.py
+++ b/discovery_utils/horizon_scout/inference_bert.py
@@ -1,0 +1,101 @@
+from typing import List
+
+import pandas as pd
+
+from discovery_utils import logging
+from discovery_utils.getters.horizon_scout import get_bert_classifier
+from discovery_utils.utils import s3
+
+
+logging.basicConfig(level=logging.INFO)
+
+client = s3.s3_client()
+
+
+def bert_predictions(mission: str, model_filename: str, df: pd.DataFrame, text_col: str, label2id: dict) -> list:
+    """Use BERT classifier to make a list of predictions
+
+    Args:
+       mission (str): Nesta mission ('AHL', 'AFS' or 'ASF').
+       model_filename (str): Filename on S3 e.g. 'AHL_bert_0.965_20240530-2244.pkl'
+       df (pd.DataFrame): Input DataFrame containing the text data.
+       text_col (str): Column name for the text in the DataFrame.
+       label2id (dict): Dict that maps label to id.
+
+    Returns:
+       list: List of predictions
+    """
+    # Load the classifier
+    bert_classifier = get_bert_classifier(mission, model_filename)
+
+    # Make predictions on the text data
+    texts = df[text_col].tolist()
+    predictions = bert_classifier(texts)
+
+    # Convert predictions to 0s and 1s using label2id
+    predicted_labels = [label2id[pred["label"]] for pred in predictions]
+
+    return predicted_labels
+
+
+def bert_add_predictions(
+    missions: List[str],
+    model_filenames: List[str],
+    df: pd.DataFrame,
+    text_col: str,
+    label2id: dict,
+    predictions_cols: List[str],
+) -> pd.DataFrame:
+    """Use BERT classifier to add predictions to input DataFrame
+
+    Args:
+       mission (str): Nesta mission ('AHL', 'AFS' or 'ASF').
+       model_filename (str): Filename on S3 e.g. 'AHL_bert_0.965_20240530-2244.pkl'
+       df (pd.DataFrame): Input DataFrame containing the text data.
+       text_col (str): Column name for the text in the DataFrame.
+       label2id (dict): Dict that maps label to id.
+       predictions_col (str): Column name to assign the predictions to.
+
+    Returns:
+       pd.DataFrame: DataFrame with predictions from each mission classifier added.
+    """
+    for mission, model_filename, predictions_col in zip(missions, model_filenames, predictions_cols):
+        df[predictions_col] = bert_predictions(mission, model_filename, df, text_col, label2id)
+    return df
+
+
+MISSIONS = [
+    "AHL",
+    "ASF",
+    "AFS",
+]
+MODEL_FILENAMES = [
+    "AHL_bert_0.965_20240530-2244.pkl",
+    "ASF_bert_0.931_20240530-2235.pkl",
+    "AFS_bert_0.979_20240530-2240.pkl",
+]
+PREDICTIONS_COLS = ["ahl_bert_preds", "asf_bert_preds", "afs_bert_preds"]
+LABEL2ID = {"NOT RELEVANT": 0, "RELEVANT": 1}
+SAVE_PATH = "data/crunchbase/enriched/organizations_new_only_with_bert_preds.csv"
+
+if __name__ == "__main__":
+    logging.info("Downloading new Crunchbase companies")
+    new_companies = s3._download_obj(
+        s3_client=client,
+        bucket=s3.BUCKET_NAME_RAW,
+        path_from="data/crunchbase/enriched/organizations_new_only.parquet",
+        download_as="dataframe",
+    )
+
+    logging.info("Adding BERT mission predictions")
+    new_companies_with_predictions = bert_add_predictions(
+        missions=MISSIONS,
+        model_filenames=MODEL_FILENAMES,
+        df=new_companies,
+        text_col="short_description",
+        label2id=LABEL2ID,
+        predictions_cols=PREDICTIONS_COLS,
+    )
+
+    logging.info("Saving new Crunchbase companies with BERT mission predictios to %s", SAVE_PATH)
+    s3.upload_obj(new_companies_with_predictions, s3.BUCKET_NAME_RAW, SAVE_PATH)

--- a/discovery_utils/horizon_scout/inference_bert.py
+++ b/discovery_utils/horizon_scout/inference_bert.py
@@ -3,6 +3,7 @@ from typing import List
 import pandas as pd
 import torch
 
+from botocore.exceptions import ClientError
 from tqdm import tqdm
 from transformers import AutoTokenizer
 from transformers import PreTrainedModel
@@ -10,6 +11,7 @@ from transformers import PreTrainedTokenizer
 
 from discovery_utils import logging
 from discovery_utils.getters.horizon_scout import get_bert_model
+from discovery_utils.horizon_scout.utils import get_current_datetime
 from discovery_utils.utils import s3
 
 
@@ -41,6 +43,7 @@ def bert_add_predictions(
     Returns:
         pd.DataFrame: DataFrame with new columns containing classification predictions.
     """
+    df = df.dropna(subset=text_col)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     bert_models = [model.to(device) for model in bert_models]
     total_batches = (len(df) + batch_size - 1) // batch_size
@@ -65,31 +68,89 @@ def bert_add_predictions(
     return df
 
 
-SAVE_PATH = "data/crunchbase/enriched/organizations_new_only_with_bert_preds.csv"
+def preds_to_labels(df: pd.DataFrame, missions: List[str]) -> pd.DataFrame:
+    """
+    Create a new 'label' column based on the values of 'ahl_bert_preds', 'asf_bert_preds', and 'afs_bert_preds'.
+
+    Args:
+        df (pd.DataFrame): Input DataFrame with 'ahl_bert_preds',
+            'asf_bert_preds', and 'afs_bert_preds' columns.
+        missions (List[str]): List of mission names.
+
+    Returns:
+        pd.DataFrame: DataFrame with an additional 'label' column.
+    """
+
+    def make_label(row: pd.Series) -> str:
+        return ",".join([mission for mission in missions if row[f"{mission.lower()}_bert_preds"] == 1])
+
+    df["label"] = df.apply(make_label, axis=1)
+    return df
+
+
+def check_file_exists(path: str) -> bool:
+    """Check if a file exists in an S3 bucket.
+
+    Args:
+        path (str): Path of the file within the bucket.
+
+    Returns:
+        bool: True if the file exists, False otherwise.
+    """
+
+    try:
+        client.head_object(Bucket=s3.BUCKET_NAME_RAW, Key=path)
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            return False
+        else:
+            raise e
+
+
 MISSIONS = ["AHL", "ASF", "AFS"]
 MODEL_PATHS = [
-    "AHL_bert_model_0.967_20240601-1441.pkl",
-    "ASF_bert_model_0.93_20240601-1434.pkl",
-    "AFS_bert_model_0.979_20240601-1438.pkl",
+    "AHL_bert_model_0.896_20240618-2156.pkl",
+    "ASF_bert_model_0.925_20240618-2146.pkl",
+    "AFS_bert_model_0.971_20240618-2152.pkl",
 ]
-BATCH_SIZE = 2048
+BATCH_SIZE = 512
+
+LABEL_STORE_PATH = "data/crunchbase/enriched/label_store.csv"
+NEW_ORGS_PATH = "data/crunchbase/enriched/organizations_new_only.parquet"
+FULL_ORGS_PATH = "data/crunchbase/enriched/organizations_full.parquet"
+
+LABEL_TYPE = "BERT classifiers 20240618"
+DATASET_NAME = "Crunchbase"
+
+MODE = "Full"
+MODE = "New"
 
 
 if __name__ == "__main__":
-    logging.info("Downloading new Crunchbase companies")
-    new_companies = s3._download_obj(
+    # Set data path
+    if MODE == "Full":
+        data_path = FULL_ORGS_PATH
+    elif MODE == "New":
+        data_path = NEW_ORGS_PATH
+
+    # Load data
+    logging.info("Downloading Crunchbase companies")
+    companies = s3._download_obj(
         s3_client=client,
         bucket=s3.BUCKET_NAME_RAW,
-        path_from="data/crunchbase/enriched/organizations_new_only.parquet",
+        path_from=data_path,
         download_as="dataframe",
-    )
+    )[["id", "short_description"]]
 
+    # Load models
     bert_models = [get_bert_model(mission, model_path) for mission, model_path in zip(MISSIONS, MODEL_PATHS)]
     tokenizer = AutoTokenizer.from_pretrained("distilbert/distilbert-base-uncased")
 
+    # Perform inference
     logging.info("Adding BERT mission predictions")
-    new_companies_with_predictions = bert_add_predictions(
-        df=new_companies,
+    companies = bert_add_predictions(
+        df=companies,
         text_col="short_description",
         bert_models=bert_models,
         tokenizer=tokenizer,
@@ -97,9 +158,28 @@ if __name__ == "__main__":
         batch_size=BATCH_SIZE,
     )
 
-    logging.info("Saving new Crunchbase companies with BERT mission predictions to %s", SAVE_PATH)
-    s3.upload_obj(
-        new_companies_with_predictions,
-        s3.BUCKET_NAME_RAW,
-        SAVE_PATH,
-    )
+    # Convert binary predictions to labels
+    companies = preds_to_labels(companies, MISSIONS)
+
+    # Add label type col
+    companies["label_type"] = LABEL_TYPE
+
+    # Add label date col
+    current_datetime = get_current_datetime()
+    companies["label_date"] = current_datetime
+
+    # Add dataset col
+    companies["dataset"] = DATASET_NAME
+
+    # Append to datastore, if file does not exist then create
+    if check_file_exists(LABEL_STORE_PATH):
+        label_store = s3._download_obj(
+            s3_client=client,
+            bucket=s3.BUCKET_NAME_RAW,
+            path_from=LABEL_STORE_PATH,
+            download_as="dataframe",
+        )
+        label_store = pd.concat([label_store, companies], ignore_index=True).reset_index(drop=True)
+        s3.upload_obj(label_store, s3.BUCKET_NAME_RAW, LABEL_STORE_PATH, kwargs_writing={"index": False})
+    else:
+        s3.upload_obj(companies, s3.BUCKET_NAME_RAW, LABEL_STORE_PATH, kwargs_writing={"index": False})

--- a/discovery_utils/horizon_scout/inference_bert.py
+++ b/discovery_utils/horizon_scout/inference_bert.py
@@ -19,9 +19,9 @@ client = s3.s3_client()
 # MISSIONS and MODEL_PATHS need to be in the same order
 MISSIONS = ["AHL", "ASF", "AFS"]
 MODEL_PATHS = [
-    "AHL_bert_model_0.896_20240618-2156.pkl",
-    "ASF_bert_model_0.925_20240618-2146.pkl",
-    "AFS_bert_model_0.971_20240618-2152.pkl",
+    "AHL_bert_model_0.896_20240620-1008.pkl",
+    "ASF_bert_model_0.913_20240620-0957.pkl",
+    "AFS_bert_model_0.971_20240620-1001.pkl",
 ]
 
 BATCH_SIZE = 512
@@ -31,7 +31,7 @@ NEW_ORGS_PATH = "data/crunchbase/enriched/organizations_new_only.parquet"
 FULL_ORGS_PATH = "data/crunchbase/enriched/organizations_full.parquet"
 
 # Value to set for the `label_type` column
-LABEL_TYPE = "BERT classifiers 20240618"
+LABEL_TYPE = "BERT classifiers 20240620"
 # Value to set for the `dataset` column
 DATASET = "Crunchbase"
 

--- a/discovery_utils/horizon_scout/inference_bert.py
+++ b/discovery_utils/horizon_scout/inference_bert.py
@@ -19,9 +19,9 @@ client = s3.s3_client()
 # MISSIONS and MODEL_PATHS need to be in the same order
 MISSIONS = ["AHL", "ASF", "AFS"]
 MODEL_PATHS = [
-    "AHL_bert_model_0.896_20240620-1008.pkl",
-    "ASF_bert_model_0.913_20240620-0957.pkl",
-    "AFS_bert_model_0.971_20240620-1001.pkl",
+    "AHL_bert_model_0.916_20240629-1806.pkl",
+    "ASF_bert_model_0.946_20240629-1753.pkl",
+    "AFS_bert_model_0.964_20240629-1759.pkl",
 ]
 
 BATCH_SIZE = 512
@@ -31,7 +31,7 @@ NEW_ORGS_PATH = "data/crunchbase/enriched/organizations_new_only.parquet"
 FULL_ORGS_PATH = "data/crunchbase/enriched/organizations_full.parquet"
 
 # Value to set for the `label_type` column
-LABEL_TYPE = "BERT classifiers 20240620"
+LABEL_TYPE = "BERT classifiers 20240629"
 # Value to set for the `dataset` column
 DATASET = "Crunchbase"
 

--- a/discovery_utils/horizon_scout/inference_bert.py
+++ b/discovery_utils/horizon_scout/inference_bert.py
@@ -72,7 +72,7 @@ MODEL_PATHS = [
     "ASF_bert_model_0.93_20240601-1434.pkl",
     "AFS_bert_model_0.979_20240601-1438.pkl",
 ]
-BATCH_SIZE = 512
+BATCH_SIZE = 2048
 
 
 if __name__ == "__main__":

--- a/discovery_utils/horizon_scout/inference_bert.py
+++ b/discovery_utils/horizon_scout/inference_bert.py
@@ -9,13 +9,10 @@ from transformers import AutoTokenizer
 from transformers import PreTrainedModel
 from transformers import PreTrainedTokenizer
 
-from discovery_utils import logging
 from discovery_utils.getters.horizon_scout import get_bert_model
 from discovery_utils.horizon_scout.utils import get_current_datetime
 from discovery_utils.utils import s3
 
-
-logging.basicConfig(level=logging.INFO)
 
 client = s3.s3_client()
 
@@ -33,8 +30,10 @@ LABEL_STORE_PATH = "data/crunchbase/enriched/label_store.csv"
 NEW_ORGS_PATH = "data/crunchbase/enriched/organizations_new_only.parquet"
 FULL_ORGS_PATH = "data/crunchbase/enriched/organizations_full.parquet"
 
+# Value to set for the `label_type` column
 LABEL_TYPE = "BERT classifiers 20240618"
-DATASET_NAME = "Crunchbase"
+# Value to set for the `dataset` column
+DATASET = "Crunchbase"
 
 # MODE = "Full"
 MODE = "New"
@@ -149,7 +148,6 @@ if __name__ == "__main__":
     data_path = FULL_ORGS_PATH if MODE == "Full" else NEW_ORGS_PATH
 
     # Load data and process companies
-    logging.info("Downloading Crunchbase companies")
     companies = (
         download_df(data_path)[["id", "short_description"]]
         .pipe(
@@ -161,7 +159,7 @@ if __name__ == "__main__":
             batch_size=BATCH_SIZE,
         )
         .pipe(preds_to_labels, missions=MISSIONS)
-        .assign(label_type=LABEL_TYPE, label_date=get_current_datetime(), dataset=DATASET_NAME)
+        .assign(label_type=LABEL_TYPE, label_date=get_current_datetime(), dataset=DATASET)
     )
 
     # Append to datastore, if file does not exist then create

--- a/discovery_utils/horizon_scout/inference_bert.yml
+++ b/discovery_utils/horizon_scout/inference_bert.yml
@@ -1,7 +1,6 @@
 ---
 resources:
   cloud: aws
-  #instance_type: g4dn.xlarge
   instance_type: g5.xlarge
   region: eu-west-2
 envs:

--- a/discovery_utils/horizon_scout/inference_bert.yml
+++ b/discovery_utils/horizon_scout/inference_bert.yml
@@ -1,0 +1,19 @@
+---
+resources:
+  cloud: aws
+  #instance_type: g4dn.xlarge
+  instance_type: g5.xlarge
+  region: eu-west-2
+envs:
+  BUCKET_NAME_RAW: discovery-iss
+workdir: .
+setup: |
+  cp ~/.aws/credentials ~/sky_workdir/.credentials/aws_credentials
+  cd ~/sky_workdir
+  curl -sSL https://install.python-poetry.org | python3 -
+  export PATH="/home/ubuntu/.local/bin:$PATH"
+  poetry install
+run: |
+  cd ~/sky_workdir
+  export PATH="/home/ubuntu/.local/bin:$PATH"
+  poetry run python discovery_utils/horizon_scout/inference_bert.py

--- a/discovery_utils/horizon_scout/train_bert.py
+++ b/discovery_utils/horizon_scout/train_bert.py
@@ -1,0 +1,8 @@
+from discovery_utils.getters.horizon_scout import get_training_data
+from discovery_utils.horizon_scout.utils import get_current_datetime
+
+
+if __name__ == "__main__":
+    print(get_current_datetime())  # noqa: T001
+    asf = get_training_data("ASF")
+    print(asf)  # noqa: T001

--- a/discovery_utils/horizon_scout/train_bert.py
+++ b/discovery_utils/horizon_scout/train_bert.py
@@ -13,18 +13,20 @@ from datasets import Dataset
 from transformers import AutoModelForSequenceClassification
 from transformers import AutoTokenizer
 from transformers import DataCollatorWithPadding
+from transformers import EarlyStoppingCallback
 from transformers import PreTrainedTokenizer
 from transformers import Trainer
 from transformers import TrainingArguments
 from transformers import pipeline
 
+from discovery_utils import logging
 from discovery_utils.getters.horizon_scout import get_training_data
 from discovery_utils.horizon_scout.utils import get_current_datetime
 from discovery_utils.horizon_scout.utils import make_train_val_datasets
 from discovery_utils.utils import s3
 
 
-os.environ["TRANSFORMERS_VERBOSITY"] = "info"
+logging.basicConfig(level=logging.INFO)
 
 
 def tokenize(df: pd.DataFrame, tokenizer: PreTrainedTokenizer) -> Dict[str, Any]:
@@ -67,56 +69,73 @@ def create_compute_metrics() -> Callable[[Tuple[np.ndarray, np.ndarray]], Dict[s
     return compute_metrics
 
 
-MISSION = "AHL"
-EPOCHS = 3
-ID2LABEL = {0: "NOT RELEVANT", 1: "RELEVANT"}
-LABEL2ID = {"NOT RELEVANT": 0, "RELEVANT": 1}
-BATCH_SIZE = 60
+def train_and_save_model(
+    mission: str, epochs: int, batch_size: int, id2label: Dict[int, str], label2id: Dict[str, int]
+) -> None:
+    """Train a model for a specific mission and save it to S3.
 
-if __name__ == "__main__":
+    Args:
+        mission (str): The mission name.
+        epochs (int): Number of training epochs.
+        batch_size (int): Batch size for training and evaluation.
+        id2label (Dict[int, str]): Dictionary mapping label IDs to label names.
+        label2id (Dict[str, int]): Dictionary mapping label names to label IDs.
+    """
+    logging.info("Starting %s training run", mission)
     # Make train and val dfs
-    train_df, val_df = make_train_val_datasets(get_training_data(MISSION), 13, 0.80)
+    logging.info("Making train and validation dataframes")
+    train_df, val_df = make_train_val_datasets(get_training_data(mission), 13, 0.80)
 
     # Make train and val HF datasets
+    logging.info("Making train and validation Huggingface datasets")
     train_hf_ds = Dataset.from_pandas(train_df.assign(label=lambda x: x.relevant))
     val_hf_ds = Dataset.from_pandas(val_df.assign(label=lambda x: x.relevant))
 
     # Load tokenizer
+    logging.info("Loading tokenizer")
     tokenizer = AutoTokenizer.from_pretrained("distilbert/distilbert-base-uncased")
 
     # Tokenize train and val HF datasets
+    logging.info("Tokenizing datasets")
     tokenized_train_hf_ds = train_hf_ds.map(lambda x: tokenize(x, tokenizer), batched=True)
     tokenized_val_hf_ds = val_hf_ds.map(lambda x: tokenize(x, tokenizer), batched=True)
 
     # Initialize the data collator
+    logging.info("Initializing data collator")
     data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
 
     # Load the pre-trained DistilBERT model
+    logging.info("Loading pre-trained DistilBERT model")
     model = AutoModelForSequenceClassification.from_pretrained(
-        "distilbert/distilbert-base-uncased", num_labels=2, id2label=ID2LABEL, label2id=LABEL2ID
+        "distilbert/distilbert-base-uncased", num_labels=2, id2label=id2label, label2id=label2id
     )
 
     # Retrieve the current date and time
+    logging.info("Retrieving the current date and time")
     date_time = get_current_datetime()
 
-    # Define a function to compute evaluation metrics during training.
+    # Define the function to compute evaluation metrics during training.
+    logging.info("Defining the function to compute evaluation metrics during training.")
     compute_metrics = create_compute_metrics()
 
     # Set training arguments
+    logging.info("Setting training arguments")
     training_args = TrainingArguments(
-        output_dir=os.path.expanduser(f"~/models_tmp/{MISSION}_distillbert_{date_time}"),
+        output_dir=os.path.expanduser(f"~/models_tmp/{mission}_distillbert_{date_time}"),
         learning_rate=2e-5,
-        per_device_train_batch_size=BATCH_SIZE,
-        per_device_eval_batch_size=BATCH_SIZE,
-        num_train_epochs=EPOCHS,
+        per_device_train_batch_size=batch_size,
+        per_device_eval_batch_size=batch_size,
+        num_train_epochs=epochs,
         weight_decay=0.01,
         evaluation_strategy="epoch",
         save_strategy="epoch",
         load_best_model_at_end=True,
+        metric_for_best_model="eval_accuracy",
         push_to_hub=False,
     )
 
     # Train the model
+    logging.info("Training the %s classifier", mission)
     trainer = Trainer(
         model=model,
         args=training_args,
@@ -125,27 +144,41 @@ if __name__ == "__main__":
         tokenizer=tokenizer,
         data_collator=data_collator,
         compute_metrics=compute_metrics,
+        callbacks=[EarlyStoppingCallback(early_stopping_patience=2, early_stopping_threshold=0.0001)],
     )
-
     trainer.train()
 
     # Store number of steps
     global_step = trainer.state.global_step
 
     # Store eval_accuracy
-    eval_accuracy = round([log for log in trainer.state.log_history if "eval_accuracy" in log][-1]["eval_accuracy"], 3)
+    eval_results = trainer.evaluate()
+    eval_accuracy = round(eval_results["eval_accuracy"], 3)
 
     # Load model that can be used for inference
-    model_path = os.path.expanduser(f"~/models_tmp/{MISSION}_distillbert_{date_time}/checkpoint-{global_step}")
+    model_path = os.path.expanduser(f"~/models_tmp/{mission}_distillbert_{date_time}/checkpoint-{global_step}")
     model = AutoModelForSequenceClassification.from_pretrained(model_path)
     tokenizer = AutoTokenizer.from_pretrained(model_path)
     classifier = pipeline(
-        "text-classification", model=model, tokenizer=tokenizer, truncation=True, max_length=512, batch_size=BATCH_SIZE
+        "text-classification", model=model, tokenizer=tokenizer, truncation=True, max_length=512, batch_size=batch_size
     )
 
     # Save model to S3
+    save_path = f"models/horizon_scout/{mission}/{mission}_bert_{eval_accuracy}_{date_time}.pkl"
+    logging.info("Saving the %s classifier to %s", mission, save_path)
     s3.upload_obj(
         classifier,
         s3.BUCKET_NAME_RAW,
-        f"models/horizon_scout/{MISSION}/{MISSION}_bert_{eval_accuracy}_{date_time}.pkl",
+        save_path,
     )
+
+
+MISSIONS = ["ASF", "AFS", "AHL"]
+EPOCHS = 10
+ID2LABEL = {0: "NOT RELEVANT", 1: "RELEVANT"}
+LABEL2ID = {"NOT RELEVANT": 0, "RELEVANT": 1}
+BATCH_SIZE = 60
+
+if __name__ == "__main__":
+    for mission in MISSIONS:
+        train_and_save_model(mission, EPOCHS, BATCH_SIZE, ID2LABEL, LABEL2ID)

--- a/discovery_utils/horizon_scout/train_bert.py
+++ b/discovery_utils/horizon_scout/train_bert.py
@@ -27,6 +27,12 @@ from discovery_utils.utils import s3
 
 logging.basicConfig(level=logging.INFO)
 
+MISSIONS = ["ASF", "AFS", "AHL"]
+EPOCHS = 12
+ID2LABEL = {0: "NOT RELEVANT", 1: "RELEVANT"}
+LABEL2ID = {"NOT RELEVANT": 0, "RELEVANT": 1}
+BATCH_SIZE = 60
+
 
 def tokenize(df: pd.DataFrame, tokenizer: PreTrainedTokenizer) -> Dict[str, Any]:
     """Preprocesse the text data in a DataFrame using a specified tokenizer.
@@ -160,12 +166,6 @@ def train_and_save_model(
         model_save_path,
     )
 
-
-MISSIONS = ["ASF", "AFS", "AHL"]
-EPOCHS = 12
-ID2LABEL = {0: "NOT RELEVANT", 1: "RELEVANT"}
-LABEL2ID = {"NOT RELEVANT": 0, "RELEVANT": 1}
-BATCH_SIZE = 60
 
 if __name__ == "__main__":
     for mission in MISSIONS:

--- a/discovery_utils/horizon_scout/train_bert.py
+++ b/discovery_utils/horizon_scout/train_bert.py
@@ -1,8 +1,151 @@
+import os
+
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Tuple
+
+import evaluate
+import numpy as np
+import pandas as pd
+
+from datasets import Dataset
+from transformers import AutoModelForSequenceClassification
+from transformers import AutoTokenizer
+from transformers import DataCollatorWithPadding
+from transformers import PreTrainedTokenizer
+from transformers import Trainer
+from transformers import TrainingArguments
+from transformers import pipeline
+
 from discovery_utils.getters.horizon_scout import get_training_data
 from discovery_utils.horizon_scout.utils import get_current_datetime
+from discovery_utils.horizon_scout.utils import make_train_val_datasets
+from discovery_utils.utils import s3
 
+
+os.environ["TRANSFORMERS_VERBOSITY"] = "info"
+
+
+def tokenize(df: pd.DataFrame, tokenizer: PreTrainedTokenizer) -> Dict[str, Any]:
+    """Preprocesse the text data in a DataFrame using a specified tokenizer.
+
+    Args:
+        df (pd.DataFrame): A DataFrame containing a column 'text' with text data to be tokenized.
+        tokenizer (PreTrainedTokenizer): A tokenizer instance from the transformers library.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing tokenized representations of the text data.
+    """
+    return tokenizer(df["text"], truncation=True, max_length=512)
+
+
+def create_compute_metrics() -> Callable[[Tuple[np.ndarray, np.ndarray]], Dict[str, float]]:
+    """
+    Create a compute_metrics function that computes accuracy.
+
+    Returns:
+        Callable[[Tuple[np.ndarray, np.ndarray]], Dict[str, float]]: A function that computes accuracy
+        for predictions and labels.
+    """
+    accuracy_metric = evaluate.load("accuracy")
+
+    def compute_metrics(eval_pred: Tuple[np.ndarray, np.ndarray]) -> Dict[str, float]:
+        """
+        Compute accuracy for predictions and labels.
+
+        Args:
+            eval_pred (Tuple[np.ndarray, np.ndarray]): A tuple containing predictions and labels.
+
+        Returns:
+            Dict[str, float]: A dictionary with the accuracy score.
+        """
+        predictions, labels = eval_pred
+        predictions = np.argmax(predictions, axis=1)
+        return accuracy_metric.compute(predictions=predictions, references=labels)
+
+    return compute_metrics
+
+
+MISSION = "AHL"
+EPOCHS = 3
+ID2LABEL = {0: "NOT RELEVANT", 1: "RELEVANT"}
+LABEL2ID = {"NOT RELEVANT": 0, "RELEVANT": 1}
+BATCH_SIZE = 60
 
 if __name__ == "__main__":
-    print(get_current_datetime())  # noqa: T001
-    asf = get_training_data("ASF")
-    print(asf)  # noqa: T001
+    # Make train and val dfs
+    train_df, val_df = make_train_val_datasets(get_training_data(MISSION), 13, 0.80)
+
+    # Make train and val HF datasets
+    train_hf_ds = Dataset.from_pandas(train_df.assign(label=lambda x: x.relevant))
+    val_hf_ds = Dataset.from_pandas(val_df.assign(label=lambda x: x.relevant))
+
+    # Load tokenizer
+    tokenizer = AutoTokenizer.from_pretrained("distilbert/distilbert-base-uncased")
+
+    # Tokenize train and val HF datasets
+    tokenized_train_hf_ds = train_hf_ds.map(lambda x: tokenize(x, tokenizer), batched=True)
+    tokenized_val_hf_ds = val_hf_ds.map(lambda x: tokenize(x, tokenizer), batched=True)
+
+    # Initialize the data collator
+    data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
+
+    # Load the pre-trained DistilBERT model
+    model = AutoModelForSequenceClassification.from_pretrained(
+        "distilbert/distilbert-base-uncased", num_labels=2, id2label=ID2LABEL, label2id=LABEL2ID
+    )
+
+    # Retrieve the current date and time
+    date_time = get_current_datetime()
+
+    # Define a function to compute evaluation metrics during training.
+    compute_metrics = create_compute_metrics()
+
+    # Set training arguments
+    training_args = TrainingArguments(
+        output_dir=os.path.expanduser(f"~/models_tmp/{MISSION}_distillbert_{date_time}"),
+        learning_rate=2e-5,
+        per_device_train_batch_size=BATCH_SIZE,
+        per_device_eval_batch_size=BATCH_SIZE,
+        num_train_epochs=EPOCHS,
+        weight_decay=0.01,
+        evaluation_strategy="epoch",
+        save_strategy="epoch",
+        load_best_model_at_end=True,
+        push_to_hub=False,
+    )
+
+    # Train the model
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized_train_hf_ds,
+        eval_dataset=tokenized_val_hf_ds,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+        compute_metrics=compute_metrics,
+    )
+
+    trainer.train()
+
+    # Store number of steps
+    global_step = trainer.state.global_step
+
+    # Store eval_accuracy
+    eval_accuracy = round([log for log in trainer.state.log_history if "eval_accuracy" in log][-1]["eval_accuracy"], 3)
+
+    # Load model that can be used for inference
+    model_path = os.path.expanduser(f"~/models_tmp/{MISSION}_distillbert_{date_time}/checkpoint-{global_step}")
+    model = AutoModelForSequenceClassification.from_pretrained(model_path)
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    classifier = pipeline(
+        "text-classification", model=model, tokenizer=tokenizer, truncation=True, max_length=512, batch_size=BATCH_SIZE
+    )
+
+    # Save model to S3
+    s3.upload_obj(
+        classifier,
+        s3.BUCKET_NAME_RAW,
+        f"models/horizon_scout/{MISSION}/{MISSION}_bert_{eval_accuracy}_{date_time}.pkl",
+    )

--- a/discovery_utils/horizon_scout/train_bert.yml
+++ b/discovery_utils/horizon_scout/train_bert.yml
@@ -1,7 +1,6 @@
 ---
 resources:
   cloud: aws
-  #instance_type: g4dn.xlarge
   instance_type: g5.xlarge
   region: eu-west-2
 envs:

--- a/discovery_utils/horizon_scout/train_bert.yml
+++ b/discovery_utils/horizon_scout/train_bert.yml
@@ -1,7 +1,8 @@
 ---
 resources:
   cloud: aws
-  instance_type: g4dn.xlarge
+  #instance_type: g4dn.xlarge
+  instance_type: g5.xlarge
   region: eu-west-2
 envs:
   BUCKET_NAME_RAW: discovery-iss
@@ -13,6 +14,8 @@ setup: |
   export PATH="/home/ubuntu/.local/bin:$PATH"
   poetry install
 run: |
+  mkdir ~/models_tmp
   cd ~/sky_workdir
   export PATH="/home/ubuntu/.local/bin:$PATH"
   poetry run python discovery_utils/horizon_scout/train_bert.py
+  rm -r ~/models_tmp

--- a/discovery_utils/horizon_scout/train_bert.yml
+++ b/discovery_utils/horizon_scout/train_bert.yml
@@ -1,0 +1,18 @@
+---
+resources:
+  cloud: aws
+  instance_type: g4dn.xlarge
+  region: eu-west-2
+envs:
+  BUCKET_NAME_RAW: discovery-iss
+workdir: .
+setup: |
+  cp ~/.aws/credentials ~/sky_workdir/.credentials/aws_credentials
+  cd ~/sky_workdir
+  curl -sSL https://install.python-poetry.org | python3 -
+  export PATH="/home/ubuntu/.local/bin:$PATH"
+  poetry install
+run: |
+  cd ~/sky_workdir
+  export PATH="/home/ubuntu/.local/bin:$PATH"
+  poetry run python discovery_utils/horizon_scout/train_bert.py

--- a/discovery_utils/horizon_scout/utils.py
+++ b/discovery_utils/horizon_scout/utils.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+from typing import Tuple
 
 import numpy as np
+import pandas as pd
 
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import confusion_matrix
@@ -42,3 +44,30 @@ def display_confusion_matrix(actual: np.array, predictions: np.array) -> None:
 def get_current_datetime() -> str:
     """Get the current date and time in the format yyyymmdd-hhmmss."""
     return datetime.now().strftime("%Y%m%d-%H%M")
+
+
+def make_train_val_datasets(
+    dataset: pd.DataFrame,
+    random_state: int,
+    training_frac: float,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Split the input DataFrame into  training and validation datasets.
+
+    First shuffle the dataset using a specified random state.
+    Then partitions the dataset into training and validation sets.
+
+    Args:
+        dataset (pd.DataFrame): The complete dataset to be split.
+        random_state (int): A seed used by the random number generator for shuffling the data.
+        training_frac (float): The fraction of the dataset to allocate to the training set.
+
+    Returns:
+        Tuple[pd.DataFrame, pd.DataFrame]: A tuple containing two DataFrames:
+        (training_dataset, val_dataset).
+    """
+    shuffled_dataset = dataset.sample(frac=1, random_state=random_state)
+    train_size = int(len(shuffled_dataset) * training_frac)
+    train_dataset = shuffled_dataset[:train_size]
+    val_dataset = shuffled_dataset[train_size:]
+    return (train_dataset.reset_index(drop=True), val_dataset.reset_index(drop=True))

--- a/notebooks/train_classifiers.ipynb
+++ b/notebooks/train_classifiers.ipynb
@@ -1,973 +1,645 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "80b971e6-53f6-4740-8132-cf257be7346f",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/jr/Documents/discovery_utils/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
-   "source": [
-    "from discovery_utils.getters.horizon_scout import get_training_data\n",
-<<<<<<< HEAD
-    "from discovery_utils.enrichment.crunchbase import _enrich_keyword_labels"
-=======
-    "from discovery_utils.enrichment.crunchbase import _enrich_keyword_labels\n",
-    "from discovery_utils.horizon_scout.utils import display_confusion_matrix"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "7bb84878",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "from typing import Tuple\n",
-    "import numpy as np\n",
-<<<<<<< HEAD
-    "from sklearn.metrics import confusion_matrix, precision_score, recall_score, accuracy_score\n",
-=======
->>>>>>> 0edcda0 (Training and inference for SVC)
-    "from sklearn.svm import SVC\n",
-    "from sklearn.linear_model import LogisticRegression\n",
-    "from sklearn.neighbors import KNeighborsClassifier"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "d63d97ab",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def make_train_val_datasets(\n",
-    "    dataset: pd.DataFrame,\n",
-    "    random_state=int,\n",
-    "    training_frac=float,\n",
-    "    ) -> Tuple[pd.DataFrame, pd.DataFrame]:\n",
-    "    \"\"\"\n",
-    "    Split the input DataFrame into  training and validation datasets.\n",
-    "\n",
-    "    First shuffle the dataset using a specified random state.\n",
-    "    Then partitions the dataset into training and validation sets.\n",
-    "\n",
-    "    Args:\n",
-    "        dataset (pd.DataFrame): The complete dataset to be split.\n",
-    "        random_state (int): A seed used by the random number generator for shuffling the data.\n",
-    "        training_frac (float): The fraction of the dataset to allocate to the training set.\n",
-    "\n",
-    "    Returns:\n",
-    "        Tuple[pd.DataFrame, pd.DataFrame]: A tuple containing two DataFrames:\n",
-    "        (training_dataset, val_dataset).\n",
-    "    \"\"\"\n",
-    "    shuffled_dataset = dataset.sample(frac=1, random_state=random_state)\n",
-    "    train_size = int(len(shuffled_dataset) * training_frac)\n",
-    "    train_dataset = shuffled_dataset[:train_size]\n",
-    "    val_dataset = shuffled_dataset[train_size:]\n",
-    "    return (train_dataset.reset_index(drop=True), val_dataset.reset_index(drop=True))\n",
-    "\n",
-    "\n",
-    "def make_train_X_train_y_val_X_val_y(\n",
-    "    train_dataset: pd.DataFrame,\n",
-    "    val_dataset: pd.DataFrame\n",
-    "    ) -> Tuple[np.array, np.array, np.array, np.array]:\n",
-    "    \"\"\"\n",
-    "    Create training and validation feature (embeddings) and target arrays.\n",
-    "\n",
-    "    Args:\n",
-    "        train_dataset (pd.DataFrame): The training dataset containing features and target.\n",
-    "        val_dataset (pd.DataFrame): The validation dataset containing features and target.\n",
-    "\n",
-    "    Returns:\n",
-    "        Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: A tuple containing four arrays:\n",
-    "        (train_X, train_y, val_X, val_y).\n",
-    "    \"\"\"\n",
-    "    train_X = np.vstack(train_dataset.embedding.values)\n",
-    "    train_y = train_dataset.relevant.values\n",
-    "    val_X = np.vstack(val_dataset.embedding.values)\n",
-    "    val_y = val_dataset.relevant.values\n",
-    "    return (train_X, train_y, val_X, val_y)\n",
-<<<<<<< HEAD
-    "\n",
-    "    \n",
-    "def print_confusion_matrix(actual: np.array, predictions: np.array):\n",
-    "    \"\"\"\n",
-    "    Print the confusion matrix along with precision, recall, and accuracy metrics.\n",
-    "\n",
-    "    Args:\n",
-    "        actual (np.ndarray): Array of actual target values.\n",
-    "        predictions (np.ndarray): Array of predicted target values.\n",
-    "    \"\"\"\n",
-    "    cm = confusion_matrix(actual, predictions)\n",
-    "    \n",
-    "    classes = ['Neg', 'Pos']\n",
-    "    \n",
-    "    print('            Predicted:')\n",
-    "    print('            | {:<4} | {:<4} |'.format(*classes))\n",
-    "    print('-----------------------------')\n",
-    "    for i, row in enumerate(cm):\n",
-    "        print('Actual {:<4} | {:<4} | {:<4} |'.format(classes[i], *row))\n",
-    "    print()\n",
-    "    \n",
-    "    precision = precision_score(actual, predictions, average='binary')\n",
-    "    recall = recall_score(actual, predictions, average='binary')\n",
-    "    accuracy = accuracy_score(actual, predictions)\n",
-    "\n",
-    "    print(f\"Precision: {precision:.3f}\")\n",
-    "    print(f\"Recall: {recall:.3f}\")\n",
-    "    print(f\"Accuracy: {accuracy:.3f}\")\n",
-=======
->>>>>>> 0edcda0 (Training and inference for SVC)
-    "    \n",
-    "    \n",
-    "def classify_by_keywords(dataset: pd.DataFrame, mission: str) -> pd.DataFrame:\n",
-    "    \"\"\"Classify mission relevance by keywords.\n",
-    "    \n",
-    "    Args:\n",
-    "        dataset (pd.DataFrame): Dataset to be classified. Must have column \"text\" and \"id\".\n",
-    "        mission (str): Mission ('AHL', 'ASF' or 'AFS')\n",
-    "    \"\"\"\n",
-    "    return (\n",
-    "        dataset\n",
-    "        .merge(_enrich_keyword_labels(dataset, mission).assign(prediction=1), how=\"left\", on=\"id\")\n",
-    "        .fillna({\"prediction\": 0})\n",
-    "        .assign(correct=lambda x: (x['relevant'] == x['prediction']))\n",
-    "        .astype({\"correct\": int, \"prediction\": int})\n",
-    "        .drop(columns=\"topic_label\")\n",
-    "        .drop_duplicates(subset=\"id\")\n",
-    "    )\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "d3e1fedf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Make train and val datasets for AHL\n",
-    "ahl_training_data = get_training_data(\"AHL\")\n",
-    "ahl_train, ahl_val = make_train_val_datasets(ahl_training_data, 13, 0.85)\n",
-    "ahl_train_X, ahl_train_y, ahl_val_X, ahl_val_y = make_train_X_train_y_val_X_val_y(ahl_train, ahl_val)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "85460770",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 249  | 2    |\n",
-      "Actual Pos  | 83   | 182  |\n",
-      "\n",
-      "Precision: 0.989\n",
-      "Recall: 0.687\n",
-      "Accuracy: 0.835\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg | 1114 |   15 |\n",
-      "INFO:root:Actual Pos |  821 |  209 |\n",
-      "INFO:root:Precision: 0.933\n",
-      "INFO:root:Recall: 0.203\n",
-      "INFO:root:Accuracy: 0.613\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Keyword classifier AHL\n",
-    "ahl_val_with_preds = classify_by_keywords(ahl_val, \"AHL\")\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(ahl_val_with_preds.relevant.values, ahl_val_with_preds.prediction.values)"
-=======
-    "display_confusion_matrix(ahl_val_with_preds.relevant.values, ahl_val_with_preds.prediction.values)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "7bd77228",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 238  | 13   |\n",
-      "Actual Pos  | 19   | 246  |\n",
-      "\n",
-      "Precision: 0.950\n",
-      "Recall: 0.928\n",
-      "Accuracy: 0.938\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg | 1012 |  117 |\n",
-      "INFO:root:Actual Pos |   96 |  934 |\n",
-      "INFO:root:Precision: 0.889\n",
-      "INFO:root:Recall: 0.907\n",
-      "INFO:root:Accuracy: 0.901\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Linear SVM performance AHL\n",
-    "linear_svm_ahl_classifier = SVC(kernel='linear', C=2)\n",
-    "linear_svm_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
-    "linear_svm_ahl_preds = linear_svm_ahl_classifier.predict(ahl_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(ahl_val_y, linear_svm_ahl_preds)"
-=======
-    "display_confusion_matrix(ahl_val_y, linear_svm_ahl_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "fa61ddd4",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 244  | 7    |\n",
-      "Actual Pos  | 15   | 250  |\n",
-      "\n",
-      "Precision: 0.973\n",
-      "Recall: 0.943\n",
-      "Accuracy: 0.957\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg | 1045 |   84 |\n",
-      "INFO:root:Actual Pos |   71 |  959 |\n",
-      "INFO:root:Precision: 0.919\n",
-      "INFO:root:Recall: 0.931\n",
-      "INFO:root:Accuracy: 0.928\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Poly SVM performance AHL\n",
-    "poly_svm_ahl_classifier = SVC(kernel='poly', degree=4, C=0.3, gamma='scale', coef0=0.5)\n",
-    "poly_svm_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
-    "poly_svm_ahl_preds = poly_svm_ahl_classifier.predict(ahl_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(ahl_val_y, poly_svm_ahl_preds)"
-=======
-    "display_confusion_matrix(ahl_val_y, poly_svm_ahl_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "af6bf092",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 240  | 11   |\n",
-      "Actual Pos  | 22   | 243  |\n",
-      "\n",
-      "Precision: 0.957\n",
-      "Recall: 0.917\n",
-      "Accuracy: 0.936\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg | 1016 |  113 |\n",
-      "INFO:root:Actual Pos |   94 |  936 |\n",
-      "INFO:root:Precision: 0.892\n",
-      "INFO:root:Recall: 0.909\n",
-      "INFO:root:Accuracy: 0.904\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# LR performance AHL\n",
-    "lr_ahl_classifier = LogisticRegression(solver='lbfgs', max_iter=50, C=1)\n",
-    "lr_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
-    "lr_ahl_preds = lr_ahl_classifier.predict(ahl_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(ahl_val_y, lr_ahl_preds)"
-=======
-    "display_confusion_matrix(ahl_val_y, lr_ahl_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "6e972582",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 232  | 19   |\n",
-      "Actual Pos  | 10   | 255  |\n",
-      "\n",
-      "Precision: 0.931\n",
-      "Recall: 0.962\n",
-      "Accuracy: 0.944\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  987 |  142 |\n",
-      "INFO:root:Actual Pos |   61 |  969 |\n",
-      "INFO:root:Precision: 0.872\n",
-      "INFO:root:Recall: 0.941\n",
-      "INFO:root:Accuracy: 0.906\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# KNN performance AHL\n",
-    "knn_ahl_classifier = KNeighborsClassifier(n_neighbors=4)\n",
-    "knn_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
-    "knn_ahl_preds = knn_ahl_classifier.predict(ahl_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(ahl_val_y, knn_ahl_preds)"
-=======
-    "display_confusion_matrix(ahl_val_y, knn_ahl_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "4ea4e7a1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Make train and val datasets for ASF\n",
-    "asf_training_data = get_training_data(\"ASF\")\n",
-    "asf_train, asf_val = make_train_val_datasets(asf_training_data, 13, 0.85)\n",
-    "asf_train_X, asf_train_y, asf_val_X, asf_val_y = make_train_X_train_y_val_X_val_y(asf_train, asf_val)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "21fcfb02",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 226  | 6    |\n",
-      "Actual Pos  | 120  | 122  |\n",
-      "\n",
-      "Precision: 0.953\n",
-      "Recall: 0.504\n",
-      "Accuracy: 0.734\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  232 |    9 |\n",
-      "INFO:root:Actual Pos |  125 |  124 |\n",
-      "INFO:root:Precision: 0.932\n",
-      "INFO:root:Recall: 0.498\n",
-      "INFO:root:Accuracy: 0.727\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Keyword classifier ASF\n",
-    "asf_val_with_preds = classify_by_keywords(asf_val, \"ASF\")\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(asf_val_with_preds.relevant.values, asf_val_with_preds.prediction.values)"
-=======
-    "display_confusion_matrix(asf_val_with_preds.relevant.values, asf_val_with_preds.prediction.values)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "35332423",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 216  | 16   |\n",
-      "Actual Pos  | 28   | 214  |\n",
-      "\n",
-      "Precision: 0.930\n",
-      "Recall: 0.884\n",
-      "Accuracy: 0.907\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  224 |   17 |\n",
-      "INFO:root:Actual Pos |   47 |  202 |\n",
-      "INFO:root:Precision: 0.922\n",
-      "INFO:root:Recall: 0.811\n",
-      "INFO:root:Accuracy: 0.869\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Linear SVM performance ASF\n",
-    "linear_svm_asf_classifier = SVC(kernel='linear', C=0.1)\n",
-    "linear_svm_asf_classifier.fit(asf_train_X, asf_train_y)\n",
-    "linear_svm_asf_preds = linear_svm_asf_classifier.predict(asf_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(asf_val_y, linear_svm_asf_preds)"
-=======
-    "display_confusion_matrix(asf_val_y, linear_svm_asf_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "ed8766fb",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 220  | 12   |\n",
-      "Actual Pos  | 23   | 219  |\n",
-      "\n",
-      "Precision: 0.948\n",
-      "Recall: 0.905\n",
-      "Accuracy: 0.926\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  225 |   16 |\n",
-      "INFO:root:Actual Pos |   33 |  216 |\n",
-      "INFO:root:Precision: 0.931\n",
-      "INFO:root:Recall: 0.867\n",
-      "INFO:root:Accuracy: 0.900\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Poly SVM performance ASF\n",
-    "poly_svm_asf_classifier = SVC(kernel='poly', degree=4, C=0.3, gamma='scale', coef0=0.5)\n",
-    "poly_svm_asf_classifier.fit(asf_train_X, asf_train_y)\n",
-    "poly_svm_asf_preds = poly_svm_asf_classifier.predict(asf_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(asf_val_y, poly_svm_asf_preds)"
-=======
-    "display_confusion_matrix(asf_val_y, poly_svm_asf_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "20c6712f",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 220  | 12   |\n",
-      "Actual Pos  | 27   | 215  |\n",
-      "\n",
-      "Precision: 0.947\n",
-      "Recall: 0.888\n",
-      "Accuracy: 0.918\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  222 |   19 |\n",
-      "INFO:root:Actual Pos |   39 |  210 |\n",
-      "INFO:root:Precision: 0.917\n",
-      "INFO:root:Recall: 0.843\n",
-      "INFO:root:Accuracy: 0.882\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# LR performance ASF\n",
-    "lr_asf_classifier = LogisticRegression(solver='newton-cg', penalty=\"l2\", C=3)\n",
-    "lr_asf_classifier.fit(asf_train_X, asf_train_y)\n",
-    "lr_asf_preds = lr_asf_classifier.predict(asf_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(asf_val_y, lr_asf_preds)"
-=======
-    "display_confusion_matrix(asf_val_y, lr_asf_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "4da1aaeb",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 205  | 27   |\n",
-      "Actual Pos  | 11   | 231  |\n",
-      "\n",
-      "Precision: 0.895\n",
-      "Recall: 0.955\n",
-      "Accuracy: 0.920\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  205 |   36 |\n",
-      "INFO:root:Actual Pos |   21 |  228 |\n",
-      "INFO:root:Precision: 0.864\n",
-      "INFO:root:Recall: 0.916\n",
-      "INFO:root:Accuracy: 0.884\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# KNN performance ASF\n",
-    "knn_asf_classifier = KNeighborsClassifier(n_neighbors=10)\n",
-    "knn_asf_classifier.fit(asf_train_X, asf_train_y)\n",
-    "knn_asf_preds = knn_asf_classifier.predict(asf_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(asf_val_y, knn_asf_preds)"
-=======
-    "display_confusion_matrix(asf_val_y, knn_asf_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "7202fe9f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Make train and val datasets for AFS\n",
-    "afs_training_data = get_training_data(\"AFS\")\n",
-    "afs_train, afs_val = make_train_val_datasets(afs_training_data, 13, 0.85)\n",
-    "afs_train_X, afs_train_y, afs_val_X, afs_val_y = make_train_X_train_y_val_X_val_y(afs_train, afs_val)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "934aee3d",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 205  | 12   |\n",
-      "Actual Pos  | 62   | 167  |\n",
-      "\n",
-      "Precision: 0.933\n",
-      "Recall: 0.729\n",
-      "Accuracy: 0.834\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  216 |    4 |\n",
-      "INFO:root:Actual Pos |   63 |  176 |\n",
-      "INFO:root:Precision: 0.978\n",
-      "INFO:root:Recall: 0.736\n",
-      "INFO:root:Accuracy: 0.854\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Keyword classifier AFS\n",
-    "afs_val_with_preds = classify_by_keywords(afs_val, \"AFS\")\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(afs_val_with_preds.relevant.values, afs_val_with_preds.prediction.values)"
-=======
-    "display_confusion_matrix(afs_val_with_preds.relevant.values, afs_val_with_preds.prediction.values)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "e637250a",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 210  | 7    |\n",
-      "Actual Pos  | 6    | 223  |\n",
-      "\n",
-      "Precision: 0.970\n",
-      "Recall: 0.974\n",
-      "Accuracy: 0.971\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  199 |   21 |\n",
-      "INFO:root:Actual Pos |    9 |  230 |\n",
-      "INFO:root:Precision: 0.916\n",
-      "INFO:root:Recall: 0.962\n",
-      "INFO:root:Accuracy: 0.935\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Linear SVM performance AFS\n",
-    "linear_svm_afs_classifier = SVC(kernel='linear', C=0.1)\n",
-    "linear_svm_afs_classifier.fit(afs_train_X, afs_train_y)\n",
-    "linear_svm_afs_preds = linear_svm_afs_classifier.predict(afs_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(afs_val_y, linear_svm_afs_preds)"
-=======
-    "display_confusion_matrix(afs_val_y, linear_svm_afs_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "cf6ace67",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 211  | 6    |\n",
-      "Actual Pos  | 7    | 222  |\n",
-      "\n",
-      "Precision: 0.974\n",
-      "Recall: 0.969\n",
-      "Accuracy: 0.971\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  201 |   19 |\n",
-      "INFO:root:Actual Pos |   14 |  225 |\n",
-      "INFO:root:Precision: 0.922\n",
-      "INFO:root:Recall: 0.941\n",
-      "INFO:root:Accuracy: 0.928\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# Poly SVM performance AFS\n",
-    "poly_svm_afs_classifier = SVC(kernel='poly', degree=4, C=0.1, gamma='scale', coef0=0.5)\n",
-    "poly_svm_afs_classifier.fit(afs_train_X, afs_train_y)\n",
-    "poly_svm_afs_preds = poly_svm_afs_classifier.predict(afs_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(afs_val_y, poly_svm_afs_preds)"
-=======
-    "display_confusion_matrix(afs_val_y, poly_svm_afs_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "24892c8b",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 211  | 6    |\n",
-      "Actual Pos  | 8    | 221  |\n",
-      "\n",
-      "Precision: 0.974\n",
-      "Recall: 0.965\n",
-      "Accuracy: 0.969\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  205 |   15 |\n",
-      "INFO:root:Actual Pos |   12 |  227 |\n",
-      "INFO:root:Precision: 0.938\n",
-      "INFO:root:Recall: 0.950\n",
-      "INFO:root:Accuracy: 0.941\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# LR performance AFS\n",
-    "lr_afs_classifier = LogisticRegression(solver='saga', penalty=\"l2\", max_iter=100, C=8)\n",
-    "lr_afs_classifier.fit(afs_train_X, afs_train_y)\n",
-    "lr_afs_preds = lr_afs_classifier.predict(afs_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(afs_val_y, lr_afs_preds)"
-=======
-    "display_confusion_matrix(afs_val_y, lr_afs_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "890617de",
-   "metadata": {},
-   "outputs": [
-    {
-<<<<<<< HEAD
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            Predicted:\n",
-      "            | Neg  | Pos  |\n",
-      "-----------------------------\n",
-      "Actual Neg  | 196  | 21   |\n",
-      "Actual Pos  | 4    | 225  |\n",
-      "\n",
-      "Precision: 0.915\n",
-      "Recall: 0.983\n",
-      "Accuracy: 0.944\n"
-=======
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:            Predicted:\n",
-      "INFO:root:            | Neg | Pos |\n",
-      "INFO:root:-----------------------------\n",
-      "INFO:root:Actual Neg |  186 |   34 |\n",
-      "INFO:root:Actual Pos |    1 |  238 |\n",
-      "INFO:root:Precision: 0.875\n",
-      "INFO:root:Recall: 0.996\n",
-      "INFO:root:Accuracy: 0.924\n"
->>>>>>> 0edcda0 (Training and inference for SVC)
-     ]
-    }
-   ],
-   "source": [
-    "# KNN performance AFS\n",
-    "knn_afs_classifier = KNeighborsClassifier(n_neighbors=5)\n",
-    "knn_afs_classifier.fit(afs_train_X, afs_train_y)\n",
-    "knn_afs_preds = knn_afs_classifier.predict(afs_val_X)\n",
-<<<<<<< HEAD
-    "print_confusion_matrix(afs_val_y, knn_afs_preds)"
-=======
-    "display_confusion_matrix(afs_val_y, knn_afs_preds)"
->>>>>>> 0edcda0 (Training and inference for SVC)
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "7ce01f66",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ahl_train.to_csv(\"ahl_train.csv\", index=False)\n",
-    "ahl_val.to_csv(\"ahl_val.csv\", index=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "29428803",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "asf_train.to_csv(\"asf_train.csv\", index=False)\n",
-    "asf_val.to_csv(\"asf_val.csv\", index=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "152da844",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "afs_train.to_csv(\"afs_train.csv\", index=False)\n",
-    "afs_val.to_csv(\"afs_val.csv\", index=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-<<<<<<< HEAD
-   "id": "bfe41220",
-=======
-   "id": "500299aa",
->>>>>>> 0edcda0 (Training and inference for SVC)
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "80b971e6-53f6-4740-8132-cf257be7346f",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "/Users/jr/Documents/discovery_utils/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+                        "  from .autonotebook import tqdm as notebook_tqdm\n"
+                    ]
+                }
+            ],
+            "source": [
+                "from discovery_utils.getters.horizon_scout import get_training_data\n",
+                "from discovery_utils.enrichment.crunchbase import _enrich_keyword_labels\n",
+                "from discovery_utils.horizon_scout.utils import display_confusion_matrix"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "7bb84878",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import pandas as pd\n",
+                "from typing import Tuple\n",
+                "import numpy as np\n",
+                "from sklearn.svm import SVC\n",
+                "from sklearn.linear_model import LogisticRegression\n",
+                "from sklearn.neighbors import KNeighborsClassifier"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "id": "d63d97ab",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "def make_train_val_datasets(\n",
+                "    dataset: pd.DataFrame,\n",
+                "    random_state=int,\n",
+                "    training_frac=float,\n",
+                "    ) -> Tuple[pd.DataFrame, pd.DataFrame]:\n",
+                "    \"\"\"\n",
+                "    Split the input DataFrame into  training and validation datasets.\n",
+                "\n",
+                "    First shuffle the dataset using a specified random state.\n",
+                "    Then partitions the dataset into training and validation sets.\n",
+                "\n",
+                "    Args:\n",
+                "        dataset (pd.DataFrame): The complete dataset to be split.\n",
+                "        random_state (int): A seed used by the random number generator for shuffling the data.\n",
+                "        training_frac (float): The fraction of the dataset to allocate to the training set.\n",
+                "\n",
+                "    Returns:\n",
+                "        Tuple[pd.DataFrame, pd.DataFrame]: A tuple containing two DataFrames:\n",
+                "        (training_dataset, val_dataset).\n",
+                "    \"\"\"\n",
+                "    shuffled_dataset = dataset.sample(frac=1, random_state=random_state)\n",
+                "    train_size = int(len(shuffled_dataset) * training_frac)\n",
+                "    train_dataset = shuffled_dataset[:train_size]\n",
+                "    val_dataset = shuffled_dataset[train_size:]\n",
+                "    return (train_dataset.reset_index(drop=True), val_dataset.reset_index(drop=True))\n",
+                "\n",
+                "\n",
+                "def make_train_X_train_y_val_X_val_y(\n",
+                "    train_dataset: pd.DataFrame,\n",
+                "    val_dataset: pd.DataFrame\n",
+                "    ) -> Tuple[np.array, np.array, np.array, np.array]:\n",
+                "    \"\"\"\n",
+                "    Create training and validation feature (embeddings) and target arrays.\n",
+                "\n",
+                "    Args:\n",
+                "        train_dataset (pd.DataFrame): The training dataset containing features and target.\n",
+                "        val_dataset (pd.DataFrame): The validation dataset containing features and target.\n",
+                "\n",
+                "    Returns:\n",
+                "        Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: A tuple containing four arrays:\n",
+                "        (train_X, train_y, val_X, val_y).\n",
+                "    \"\"\"\n",
+                "    train_X = np.vstack(train_dataset.embedding.values)\n",
+                "    train_y = train_dataset.relevant.values\n",
+                "    val_X = np.vstack(val_dataset.embedding.values)\n",
+                "    val_y = val_dataset.relevant.values\n",
+                "    return (train_X, train_y, val_X, val_y)\n",
+                "    \n",
+                "    \n",
+                "def classify_by_keywords(dataset: pd.DataFrame, mission: str) -> pd.DataFrame:\n",
+                "    \"\"\"Classify mission relevance by keywords.\n",
+                "    \n",
+                "    Args:\n",
+                "        dataset (pd.DataFrame): Dataset to be classified. Must have column \"text\" and \"id\".\n",
+                "        mission (str): Mission ('AHL', 'ASF' or 'AFS')\n",
+                "    \"\"\"\n",
+                "    return (\n",
+                "        dataset\n",
+                "        .merge(_enrich_keyword_labels(dataset, mission).assign(prediction=1), how=\"left\", on=\"id\")\n",
+                "        .fillna({\"prediction\": 0})\n",
+                "        .assign(correct=lambda x: (x['relevant'] == x['prediction']))\n",
+                "        .astype({\"correct\": int, \"prediction\": int})\n",
+                "        .drop(columns=\"topic_label\")\n",
+                "        .drop_duplicates(subset=\"id\")\n",
+                "    )\n",
+                "    "
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "id": "d3e1fedf",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Make train and val datasets for AHL\n",
+                "ahl_training_data = get_training_data(\"AHL\")\n",
+                "ahl_train, ahl_val = make_train_val_datasets(ahl_training_data, 13, 0.85)\n",
+                "ahl_train_X, ahl_train_y, ahl_val_X, ahl_val_y = make_train_X_train_y_val_X_val_y(ahl_train, ahl_val)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "85460770",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg | 1114 |   15 |\n",
+                        "INFO:root:Actual Pos |  821 |  209 |\n",
+                        "INFO:root:Precision: 0.933\n",
+                        "INFO:root:Recall: 0.203\n",
+                        "INFO:root:Accuracy: 0.613\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Keyword classifier AHL\n",
+                "ahl_val_with_preds = classify_by_keywords(ahl_val, \"AHL\")\n",
+                "display_confusion_matrix(ahl_val_with_preds.relevant.values, ahl_val_with_preds.prediction.values)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "7bd77228",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg | 1012 |  117 |\n",
+                        "INFO:root:Actual Pos |   96 |  934 |\n",
+                        "INFO:root:Precision: 0.889\n",
+                        "INFO:root:Recall: 0.907\n",
+                        "INFO:root:Accuracy: 0.901\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Linear SVM performance AHL\n",
+                "linear_svm_ahl_classifier = SVC(kernel='linear', C=2)\n",
+                "linear_svm_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
+                "linear_svm_ahl_preds = linear_svm_ahl_classifier.predict(ahl_val_X)\n",
+                "display_confusion_matrix(ahl_val_y, linear_svm_ahl_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "id": "fa61ddd4",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg | 1045 |   84 |\n",
+                        "INFO:root:Actual Pos |   71 |  959 |\n",
+                        "INFO:root:Precision: 0.919\n",
+                        "INFO:root:Recall: 0.931\n",
+                        "INFO:root:Accuracy: 0.928\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Poly SVM performance AHL\n",
+                "poly_svm_ahl_classifier = SVC(kernel='poly', degree=4, C=0.3, gamma='scale', coef0=0.5)\n",
+                "poly_svm_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
+                "poly_svm_ahl_preds = poly_svm_ahl_classifier.predict(ahl_val_X)\n",
+                "display_confusion_matrix(ahl_val_y, poly_svm_ahl_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "id": "af6bf092",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg | 1016 |  113 |\n",
+                        "INFO:root:Actual Pos |   94 |  936 |\n",
+                        "INFO:root:Precision: 0.892\n",
+                        "INFO:root:Recall: 0.909\n",
+                        "INFO:root:Accuracy: 0.904\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# LR performance AHL\n",
+                "lr_ahl_classifier = LogisticRegression(solver='lbfgs', max_iter=50, C=1)\n",
+                "lr_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
+                "lr_ahl_preds = lr_ahl_classifier.predict(ahl_val_X)\n",
+                "display_confusion_matrix(ahl_val_y, lr_ahl_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 9,
+            "id": "6e972582",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  987 |  142 |\n",
+                        "INFO:root:Actual Pos |   61 |  969 |\n",
+                        "INFO:root:Precision: 0.872\n",
+                        "INFO:root:Recall: 0.941\n",
+                        "INFO:root:Accuracy: 0.906\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# KNN performance AHL\n",
+                "knn_ahl_classifier = KNeighborsClassifier(n_neighbors=4)\n",
+                "knn_ahl_classifier.fit(ahl_train_X, ahl_train_y)\n",
+                "knn_ahl_preds = knn_ahl_classifier.predict(ahl_val_X)\n",
+                "display_confusion_matrix(ahl_val_y, knn_ahl_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "id": "4ea4e7a1",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Make train and val datasets for ASF\n",
+                "asf_training_data = get_training_data(\"ASF\")\n",
+                "asf_train, asf_val = make_train_val_datasets(asf_training_data, 13, 0.85)\n",
+                "asf_train_X, asf_train_y, asf_val_X, asf_val_y = make_train_X_train_y_val_X_val_y(asf_train, asf_val)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 11,
+            "id": "21fcfb02",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  232 |    9 |\n",
+                        "INFO:root:Actual Pos |  125 |  124 |\n",
+                        "INFO:root:Precision: 0.932\n",
+                        "INFO:root:Recall: 0.498\n",
+                        "INFO:root:Accuracy: 0.727\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Keyword classifier ASF\n",
+                "asf_val_with_preds = classify_by_keywords(asf_val, \"ASF\")\n",
+                "display_confusion_matrix(asf_val_with_preds.relevant.values, asf_val_with_preds.prediction.values)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 12,
+            "id": "35332423",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  224 |   17 |\n",
+                        "INFO:root:Actual Pos |   47 |  202 |\n",
+                        "INFO:root:Precision: 0.922\n",
+                        "INFO:root:Recall: 0.811\n",
+                        "INFO:root:Accuracy: 0.869\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Linear SVM performance ASF\n",
+                "linear_svm_asf_classifier = SVC(kernel='linear', C=0.1)\n",
+                "linear_svm_asf_classifier.fit(asf_train_X, asf_train_y)\n",
+                "linear_svm_asf_preds = linear_svm_asf_classifier.predict(asf_val_X)\n",
+                "display_confusion_matrix(asf_val_y, linear_svm_asf_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 13,
+            "id": "ed8766fb",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  225 |   16 |\n",
+                        "INFO:root:Actual Pos |   33 |  216 |\n",
+                        "INFO:root:Precision: 0.931\n",
+                        "INFO:root:Recall: 0.867\n",
+                        "INFO:root:Accuracy: 0.900\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Poly SVM performance ASF\n",
+                "poly_svm_asf_classifier = SVC(kernel='poly', degree=4, C=0.3, gamma='scale', coef0=0.5)\n",
+                "poly_svm_asf_classifier.fit(asf_train_X, asf_train_y)\n",
+                "poly_svm_asf_preds = poly_svm_asf_classifier.predict(asf_val_X)\n",
+                "display_confusion_matrix(asf_val_y, poly_svm_asf_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 14,
+            "id": "20c6712f",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  222 |   19 |\n",
+                        "INFO:root:Actual Pos |   39 |  210 |\n",
+                        "INFO:root:Precision: 0.917\n",
+                        "INFO:root:Recall: 0.843\n",
+                        "INFO:root:Accuracy: 0.882\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# LR performance ASF\n",
+                "lr_asf_classifier = LogisticRegression(solver='newton-cg', penalty=\"l2\", C=3)\n",
+                "lr_asf_classifier.fit(asf_train_X, asf_train_y)\n",
+                "lr_asf_preds = lr_asf_classifier.predict(asf_val_X)\n",
+                "display_confusion_matrix(asf_val_y, lr_asf_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 15,
+            "id": "4da1aaeb",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  205 |   36 |\n",
+                        "INFO:root:Actual Pos |   21 |  228 |\n",
+                        "INFO:root:Precision: 0.864\n",
+                        "INFO:root:Recall: 0.916\n",
+                        "INFO:root:Accuracy: 0.884\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# KNN performance ASF\n",
+                "knn_asf_classifier = KNeighborsClassifier(n_neighbors=10)\n",
+                "knn_asf_classifier.fit(asf_train_X, asf_train_y)\n",
+                "knn_asf_preds = knn_asf_classifier.predict(asf_val_X)\n",
+                "display_confusion_matrix(asf_val_y, knn_asf_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 16,
+            "id": "7202fe9f",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Make train and val datasets for AFS\n",
+                "afs_training_data = get_training_data(\"AFS\")\n",
+                "afs_train, afs_val = make_train_val_datasets(afs_training_data, 13, 0.85)\n",
+                "afs_train_X, afs_train_y, afs_val_X, afs_val_y = make_train_X_train_y_val_X_val_y(afs_train, afs_val)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 17,
+            "id": "934aee3d",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  216 |    4 |\n",
+                        "INFO:root:Actual Pos |   63 |  176 |\n",
+                        "INFO:root:Precision: 0.978\n",
+                        "INFO:root:Recall: 0.736\n",
+                        "INFO:root:Accuracy: 0.854\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Keyword classifier AFS\n",
+                "afs_val_with_preds = classify_by_keywords(afs_val, \"AFS\")\n",
+                "display_confusion_matrix(afs_val_with_preds.relevant.values, afs_val_with_preds.prediction.values)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 18,
+            "id": "e637250a",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  199 |   21 |\n",
+                        "INFO:root:Actual Pos |    9 |  230 |\n",
+                        "INFO:root:Precision: 0.916\n",
+                        "INFO:root:Recall: 0.962\n",
+                        "INFO:root:Accuracy: 0.935\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Linear SVM performance AFS\n",
+                "linear_svm_afs_classifier = SVC(kernel='linear', C=0.1)\n",
+                "linear_svm_afs_classifier.fit(afs_train_X, afs_train_y)\n",
+                "linear_svm_afs_preds = linear_svm_afs_classifier.predict(afs_val_X)\n",
+                "display_confusion_matrix(afs_val_y, linear_svm_afs_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 19,
+            "id": "cf6ace67",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  201 |   19 |\n",
+                        "INFO:root:Actual Pos |   14 |  225 |\n",
+                        "INFO:root:Precision: 0.922\n",
+                        "INFO:root:Recall: 0.941\n",
+                        "INFO:root:Accuracy: 0.928\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Poly SVM performance AFS\n",
+                "poly_svm_afs_classifier = SVC(kernel='poly', degree=4, C=0.1, gamma='scale', coef0=0.5)\n",
+                "poly_svm_afs_classifier.fit(afs_train_X, afs_train_y)\n",
+                "poly_svm_afs_preds = poly_svm_afs_classifier.predict(afs_val_X)\n",
+                "display_confusion_matrix(afs_val_y, poly_svm_afs_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 20,
+            "id": "24892c8b",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  205 |   15 |\n",
+                        "INFO:root:Actual Pos |   12 |  227 |\n",
+                        "INFO:root:Precision: 0.938\n",
+                        "INFO:root:Recall: 0.950\n",
+                        "INFO:root:Accuracy: 0.941\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# LR performance AFS\n",
+                "lr_afs_classifier = LogisticRegression(solver='saga', penalty=\"l2\", max_iter=100, C=8)\n",
+                "lr_afs_classifier.fit(afs_train_X, afs_train_y)\n",
+                "lr_afs_preds = lr_afs_classifier.predict(afs_val_X)\n",
+                "display_confusion_matrix(afs_val_y, lr_afs_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 21,
+            "id": "890617de",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "INFO:root:            Predicted:\n",
+                        "INFO:root:            | Neg | Pos |\n",
+                        "INFO:root:-----------------------------\n",
+                        "INFO:root:Actual Neg |  186 |   34 |\n",
+                        "INFO:root:Actual Pos |    1 |  238 |\n",
+                        "INFO:root:Precision: 0.875\n",
+                        "INFO:root:Recall: 0.996\n",
+                        "INFO:root:Accuracy: 0.924\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# KNN performance AFS\n",
+                "knn_afs_classifier = KNeighborsClassifier(n_neighbors=5)\n",
+                "knn_afs_classifier.fit(afs_train_X, afs_train_y)\n",
+                "knn_afs_preds = knn_afs_classifier.predict(afs_val_X)\n",
+                "display_confusion_matrix(afs_val_y, knn_afs_preds)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 22,
+            "id": "7ce01f66",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ahl_train.to_csv(\"ahl_train.csv\", index=False)\n",
+                "ahl_val.to_csv(\"ahl_val.csv\", index=False)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 23,
+            "id": "29428803",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "asf_train.to_csv(\"asf_train.csv\", index=False)\n",
+                "asf_val.to_csv(\"asf_val.csv\", index=False)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 24,
+            "id": "152da844",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "afs_train.to_csv(\"afs_train.csv\", index=False)\n",
+                "afs_val.to_csv(\"afs_val.csv\", index=False)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "500299aa",
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.14"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }


### PR DESCRIPTION
Closes #15.

This PR adds:
- `discovery_utils/horizon_scout/train_bert.py` script for training each of the BERT mission classifiers and saving the model to S3 which can later be used for inference (Each model is 255mb). `train_bert.py` is intended to be run using skypilot with the `discovery_utils/horizon_scout/train_bert.yml` file.
- `discovery_utils/horizon_scout/inference_bert.py` script for using the BERT mission classifier for inference. This is intended to be run using skypilot with the `discovery_utils/horizon_scout/inference_bert.yml` file. It is setup to run inference on today's new companies (by setting `MODE` variable to `"New"`) or the full Crunchbase dataset (by setting `MODE` variable to `"Full"`). The predicted labels are stored in the `label_store.csv` file. 


The inference speeds are much quicker now than when I was using colab. It now can do the full dataset (~3.5m companies) in less than an hour.

The label store is about 700mb with the full Crunchbase dataset in it with labels.

Updates:

1.
Predictions for the July 1st and 2nd new Crunchbase companies can be found [here](https://docs.google.com/spreadsheets/d/166QIt64Y2SDzH49hX_umZX9CMAvxkd4_st2OYHnBBBg/edit?usp=sharing).

Strangely, the `run` part of the skypilot execution seems to have stopped working for me (even If I change run to just echo something). No logs are produced so it's hard to work out what is going wrong. Setup still works fine. If you have the same issue, you can manually run the files by sshing into the instance, then running:
```
cd ~/sky_workdir
echo "BUCKET_NAME_RAW=discovery-iss" > .env
source .env
source ~/sky_workdir/.venv/bin/activate
poetry run python discovery_utils/horizon_scout/inference_bert.py
```

2.
I noticed that the inference prediction accuracy would decrease when using a larger dataset (such as the full Crunchbase dataset). It seemed when the dataset was larger than 5,000 records the predictions for the records with > 5,000 index were much poorer. I could not figure out what was causing the issue (It did not seem to be an issue with GPU memory/cache. I tried using both the prediction loop I wrote and using the standard transformers 'text-classification' pipeline but the issue persisted). I have updated the inference process to chunk datasets into 5,000 record chunks and then concat the results when all predictions are made so that the prediction accuracy does not degrade with larger datasets. This method is slightly slower but the full Crunchbase dataset can still be labelled in under an hour.