### PR TITLE
Factor out keyword utils

### DIFF
--- a/discovery_utils/enrichment/crunchbase.py
+++ b/discovery_utils/enrichment/crunchbase.py
@@ -20,7 +20,7 @@ import pandas as pd
 from currency_converter import CurrencyConverter
 
 from discovery_utils.utils import google
-from discovery_utils.utils.keyword_utils import enrich_topic_labels
+from utils.keywords import enrich_topic_labels
 
 
 from typing import Dict, Iterator, List, Tuple  # isort: skip

--- a/discovery_utils/enrichment/crunchbase.py
+++ b/discovery_utils/enrichment/crunchbase.py
@@ -11,7 +11,6 @@ python discovery_utils/enrichment/crunchbase.py --test
 
 import argparse
 import os
-import re
 
 import dotenv
 import numpy as np
@@ -20,10 +19,10 @@ import pandas as pd
 from currency_converter import CurrencyConverter
 
 from discovery_utils.utils import google
-from utils.keywords import enrich_topic_labels
+from discovery_utils.utils.keywords import enrich_topic_labels
 
 
-from typing import Dict, Iterator, List, Tuple  # isort: skip
+from typing import Iterator  # isort: skip
 
 dotenv.load_dotenv()
 
@@ -467,7 +466,7 @@ def enrich_organisations(
 
     if enrich_labels:
         text_df = get_organisation_descriptions(organisations, organisation_descriptions)
-        topic_labels = enrich_topic_labels(text_df)
+        topic_labels = enrich_topic_labels(text_df.query("id in @organisation_ids"))
         return organisations_enriched.merge(topic_labels, how="left", on="id").pipe(
             _enrich_org_is_smart_money,
             funding_rounds_enriched=funding_rounds_enriched,

--- a/discovery_utils/utils/keyword_utils.py
+++ b/discovery_utils/utils/keyword_utils.py
@@ -1,0 +1,239 @@
+"""
+keyword_utils.py
+
+This module contains utility functions for processing and analyzing keywords
+in text data. It provides functionality for keyword extraction, sentence splitting,
+and label enrichment based on keyword matches.
+"""
+
+import os
+import re
+
+import numpy as np
+import pandas as pd
+
+from discovery_utils.utils import google
+
+
+from typing import Dict, List, Tuple, Union  # isort: skip
+
+
+def process_keywords(keywords: List[str], separator: str = ",") -> List[List[str]]:
+    """Process a list of keywords and keyword combinations
+
+    Args:
+        keywords (List[str]): list of keywords in the format ['keyword_1', 'keyword_2, keyword_3']
+        separator (str, optional): Character used to separate keywords. Defaults to ",".
+
+    Returns:
+        List[List[str]]: list of lists of keywords in the format ['keyword_1', ['keyword_2', 'keyword_3']]
+    """
+    return [[word.strip().replace("~", " ") for word in line.split(separator)] for line in keywords]
+
+
+def get_keywords(
+    keyword_type: str,
+) -> Dict:
+    """
+    Fetch keywords from a Google Sheet
+
+    Keywords types correspond to missions and are ASF, AFS, AHL, and X.
+
+    Args:
+        keyword_type (str): Type of keywords to fetch (e.g., 'ASF', 'AFS', 'AHL', 'X').
+
+    Returns:
+        Dict[str, List[List[str]]]: Dictionary of subcategories and their associated keywords.
+    """
+
+    # Process keywords
+    keywords_df = google.access_google_sheet(
+        os.environ["SHEET_ID_KEYWORDS"],
+        keyword_type,
+    )
+    return (
+        keywords_df.assign(keywords_list=lambda df: process_keywords(df["Keywords"].to_list()))
+        .groupby("Subcategory")
+        .agg(keywords=("keywords_list", list))
+        .to_dict()["keywords"]
+    )
+
+
+def split_sentences(texts: list, ids: list) -> Tuple[List]:
+    """
+    Split a list of texts into sentences and keep track of which text each sentence belongs to
+
+    Args:
+        texts (List[str]): A list of strings
+        ids (List[str]): A list of identifiers for each text
+
+    Returns:
+        Tuple[List[str], List[str]]: the first list contains the sentences, and the second list contains the identifiers
+    """
+    # precompile the regex for efficiency
+    sentence_endings = re.compile(r"(?<=[.!?]) +")
+    sentences = []
+    sentence_ids = []
+    for i, text in enumerate(texts):
+        for sentence in sentence_endings.split(text):
+            sentences.append(sentence)
+            sentence_ids.append(ids[i])
+    return sentences, sentence_ids
+
+
+def find_keyword_hits(keywords: List[List[str]], sentences: List[str]) -> List[bool]:
+    """
+    Check if sentences contain any of the keywords or keyword combinations.
+
+    Args:
+        keywords (List[List[str]]): List of keyword combinations to search for.
+        sentences (List[str]): List of sentences to search in.
+
+    Returns:
+        List[bool]: List of boolean values indicating whether each sentence contains a keyword hit.
+    """
+
+    hits = []
+    for text in sentences:
+        keyword_hits = True
+        for keyword in keywords:
+            # Note that we are looking for exact matches
+            keyword_hits = keyword_hits and (keyword in text)
+        hits.append(False or keyword_hits)
+    return hits
+
+
+def get_organisation_descriptions(
+    organisations: pd.DataFrame,
+    organisation_descriptions: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Create a full text description from the short description and the description columns
+
+    Args:
+        organisations (pd.DataFrame): DataFrame containing organisation data.
+        organisation_descriptions (pd.DataFrame): DataFrame containing detailed organisation.
+
+    Returns:
+        pd.DataFrame: A DataFrame with full descriptions associated with each organisation.
+    """
+    return (
+        organisations[["id", "short_description"]]
+        .merge(organisation_descriptions[["id", "description"]], on="id", how="left")
+        .dropna(subset=["short_description", "description"], how="all")
+        .fillna("")
+        .assign(text=lambda df: df["short_description"] + ". " + df["description"])
+        .drop(columns=["short_description", "description"])
+    )
+
+
+def enrich_keyword_labels(
+    text_df: pd.DataFrame,
+    keyword_type: str,
+) -> pd.DataFrame:
+    """
+    Enrich organisation data by adding topic and mission labels based on keyword hits
+
+    Args:
+        text_df (pd.DataFrame): DataFrame containing 'id' and 'text' columns.
+        keyword_type (str): Type of keywords to use for enrichment.
+
+    Returns:
+        pd.DataFrame: DataFrame with added 'topic_label' and 'mission_label' columns.
+    """
+    # Fetch keywords
+    subcategory_to_keywords = get_keywords(keyword_type)
+    # Split text into sentences
+    sentences, sentence_ids = split_sentences(text_df.text.to_list(), text_df.id.to_list())
+    sentence_ids = np.array(sentence_ids)
+    # General terms
+    general_term_ids = None
+
+    # to do: first check which texts that contain any general terms
+
+    # Then check for the specific, non-general terms
+    hits_df = []
+    for topic in subcategory_to_keywords:
+        hits = []
+        for keywords in subcategory_to_keywords[topic]:
+            hits.append(find_keyword_hits(keywords, sentences))
+
+        # Find if any of the subcategory keywords are present in the text
+        hits_matrix = np.array(hits).any(axis=0)
+        # Get array indices for texts with keywords
+        hits_indices = np.where(hits_matrix == True)[0]  # noqa: E712
+        if hits_indices.size == 0:
+            continue
+        # Get corresponding unique ids
+        hit_ids = set(sentence_ids[hits_indices])
+        # Check if these are general terms and keywords
+        if "general terms" in topic:
+            general_term_ids = hit_ids.copy()
+        else:
+            # Save to a dataframe
+            hits_df.append(
+                pd.DataFrame(
+                    data={
+                        "id": list(hit_ids),
+                        "topic_label": topic,
+                    }
+                )
+            )
+    if len(hits_df) == 0:
+        return pd.DataFrame(columns=["id", "topic_label", "mission_label"])
+    else:
+        hits_df = pd.concat(hits_df, ignore_index=True).assign(mission_label=keyword_type)
+        # Filter noise using general mission topic area terms
+        if general_term_ids is None:
+            return hits_df
+        else:
+            return hits_df.query("id in @general_term_ids").reset_index(drop=True)
+
+
+def transform_labels_df(
+    labels_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Group the labels DataFrame by organisation ID and aggregate the labels into sets.
+
+    Args:
+        labels_df (pd.DataFrame): DataFrame containing organisations and associated mission and topic labels
+
+    Returns:
+        pd.DataFrame: DataFrame grouped by organisation ID and aggregated label columns
+    """
+    return (
+        labels_df.groupby("id")
+        .agg(
+            mission_labels=("mission_label", lambda x: set(list(x))),
+            topic_labels=("topic_label", lambda x: set(list(x))),
+        )
+        # Coverting sets to strings
+        .assign(
+            mission_labels=lambda df: df.mission_labels.apply(lambda x: ",".join(x) if type(x) is set else x),
+            topic_labels=lambda df: df.topic_labels.apply(lambda x: ",".join(x) if type(x) is set else x),
+        )
+        .reset_index()
+    )
+
+
+def enrich_topic_labels(
+    organisations: pd.DataFrame,
+    organisation_descriptions: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Enrich organisation data by adding topic and mission labels for all missions.
+
+    Args:
+        organisations (pd.DataFrame): DataFrame containing organisation data.
+        organisation_descriptions (pd.DataFrame): DataFrame containing organisation descriptions.
+
+    Returns:
+        pd.DataFrame: DataFrame with enriched topic and mission labels.
+    """
+
+    text_df = get_organisation_descriptions(organisations, organisation_descriptions)
+    labels_df = []
+    for mission in ["ASF", "AHL", "AFS", "X"]:
+        labels_df.append(enrich_keyword_labels(text_df, mission))
+    return pd.concat(labels_df, ignore_index=True).pipe(transform_labels_df)

--- a/discovery_utils/utils/keyword_utils.py
+++ b/discovery_utils/utils/keyword_utils.py
@@ -103,36 +103,12 @@ def find_keyword_hits(keywords: List[List[str]], sentences: List[str]) -> List[b
     return hits
 
 
-def get_organisation_descriptions(
-    organisations: pd.DataFrame,
-    organisation_descriptions: pd.DataFrame,
-) -> pd.DataFrame:
-    """
-    Create a full text description from the short description and the description columns
-
-    Args:
-        organisations (pd.DataFrame): DataFrame containing organisation data.
-        organisation_descriptions (pd.DataFrame): DataFrame containing detailed organisation.
-
-    Returns:
-        pd.DataFrame: A DataFrame with full descriptions associated with each organisation.
-    """
-    return (
-        organisations[["id", "short_description"]]
-        .merge(organisation_descriptions[["id", "description"]], on="id", how="left")
-        .dropna(subset=["short_description", "description"], how="all")
-        .fillna("")
-        .assign(text=lambda df: df["short_description"] + ". " + df["description"])
-        .drop(columns=["short_description", "description"])
-    )
-
-
 def enrich_keyword_labels(
     text_df: pd.DataFrame,
     keyword_type: str,
 ) -> pd.DataFrame:
     """
-    Enrich organisation data by adding topic and mission labels based on keyword hits
+    Enrich text dataframe by adding topic and mission labels based on keyword hits
 
     Args:
         text_df (pd.DataFrame): DataFrame containing 'id' and 'text' columns.
@@ -194,13 +170,13 @@ def transform_labels_df(
     labels_df: pd.DataFrame,
 ) -> pd.DataFrame:
     """
-    Group the labels DataFrame by organisation ID and aggregate the labels into sets.
+    Group the labels DataFrame by ID and aggregate the labels into sets.
 
     Args:
-        labels_df (pd.DataFrame): DataFrame containing organisations and associated mission and topic labels
+        labels_df (pd.DataFrame): DataFrame containing ids and associated mission and topic labels
 
     Returns:
-        pd.DataFrame: DataFrame grouped by organisation ID and aggregated label columns
+        pd.DataFrame: DataFrame grouped by id and aggregated label columns
     """
     return (
         labels_df.groupby("id")
@@ -218,11 +194,10 @@ def transform_labels_df(
 
 
 def enrich_topic_labels(
-    organisations: pd.DataFrame,
-    organisation_descriptions: pd.DataFrame,
+    text_df: pd.DataFrame,
 ) -> pd.DataFrame:
     """
-    Enrich organisation data by adding topic and mission labels for all missions.
+    Enrich text dataframe by adding topic and mission labels for all missions.
 
     Args:
         organisations (pd.DataFrame): DataFrame containing organisation data.
@@ -232,7 +207,6 @@ def enrich_topic_labels(
         pd.DataFrame: DataFrame with enriched topic and mission labels.
     """
 
-    text_df = get_organisation_descriptions(organisations, organisation_descriptions)
     labels_df = []
     for mission in ["ASF", "AHL", "AFS", "X"]:
         labels_df.append(enrich_keyword_labels(text_df, mission))

--- a/discovery_utils/utils/keywords.py
+++ b/discovery_utils/utils/keywords.py
@@ -1,8 +1,8 @@
 """
 keyword_utils.py
 
-This module contains utility functions for processing and analyzing keywords
-in text data. It provides functionality for keyword extraction, sentence splitting,
+This module contains functions for processing and analyzing keywords in text data.
+It provides functionality for keyword extraction, sentence splitting,
 and label enrichment based on keyword matches.
 """
 
@@ -15,7 +15,7 @@ import pandas as pd
 from discovery_utils.utils import google
 
 
-from typing import Dict, List, Tuple, Union  # isort: skip
+from typing import Dict, List, Tuple  # isort: skip
 
 
 def process_keywords(keywords: List[str], separator: str = ",") -> List[List[str]]:
@@ -200,8 +200,7 @@ def enrich_topic_labels(
     Enrich text dataframe by adding topic and mission labels for all missions.
 
     Args:
-        organisations (pd.DataFrame): DataFrame containing organisation data.
-        organisation_descriptions (pd.DataFrame): DataFrame containing organisation descriptions.
+        text_df (pd.DataFrame): DataFrame containing text to be labelled and ids.
 
     Returns:
         pd.DataFrame: DataFrame with enriched topic and mission labels.

--- a/discovery_utils/utils/keywords.py
+++ b/discovery_utils/utils/keywords.py
@@ -1,5 +1,5 @@
 """
-keyword_utils.py
+discovery_utils.utils.keywords
 
 This module contains functions for processing and analyzing keywords in text data.
 It provides functionality for keyword extraction, sentence splitting,


### PR DESCRIPTION
Factored out keyword functions from crunchbase enrichment module so that they can be used for enrichment from other sources.

### Changes:
- Moved 7 keyword-related functions from `crunchbase.py` to `utils.keywords.py`:
   - _process_keywords
   - get_keywords
   - _split_sentences
   - _find_keyword_hits
   - _enrich_keyword_labels
   - _transform_labels_df
   - _enrich_topic_labels
 
- Updated `crunchbase.py` to import and use functions from `keyword_utils.py`.