### PR TITLE
[61] Wrappers for vector search in data getters

### DIFF
--- a/discovery_utils/getters/crunchbase.py
+++ b/discovery_utils/getters/crunchbase.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 import pandas as pd
 
-from sentence_transformers import SentenceTransformer
-
 from discovery_utils.utils import embeddings
 from discovery_utils.utils import s3
 
@@ -64,13 +62,12 @@ class CrunchbaseGetter:
         self._category_groups = None
         self._group_to_categories = None
         # Vector DB
-        self._vector_db_path = vector_db_path
-        self._vector_db_name = "crunchbase-lancedb"
-        self._vector_db_table_name = "company_embeddings"
-        self._vector_model_name = "all-MiniLM-L6-v2"
-        self._vector_model = None
-        self._vector_db_connection = None
-        self._vector_db = None
+        self.VectorDB = embeddings.VectorDB(
+            db_path=vector_db_path,
+            db_name="crunchbase-lancedb",
+            table_name="company_embeddings",
+            model="all-MiniLM-L6-v2",
+        )
 
     def _get_latest_data_version(self) -> str:
         """Find the latest Crunchbase version based on S3 folder timestamps."""
@@ -304,30 +301,12 @@ class CrunchbaseGetter:
     @property
     def vector_db(self) -> embeddings.LanceDBConnection:
         """Get the LanceDB connection"""
-        if self._vector_db is None:
-            self._vector_db_connection = embeddings.load_lancedb_embeddings(
-                self._vector_db_name, local_path=self._vector_db_path
-            )
-            self._vector_db = self._vector_db_connection.open_table(self._vector_db_table_name)
-            # Enable full text searches
-            try:
-                self._vector_db.create_fts_index("text")
-            except Exception as e:
-                logging.error(f"Error creating FTS index: {str(e)}")
-        return self._vector_db
-
-    @property
-    def vector_model(self) -> SentenceTransformer:
-        """Get the sentence transformer model"""
-        if self._vector_model is None:
-            self._vector_model = SentenceTransformer(self._vector_model_name)
-        return self._vector_model
+        return self.VectorDB.vector_db
 
     def text_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
         """Search the LanceDB for the query"""
-        return self.vector_db.search(query, query_type="fts").select(["id", "text"]).limit(n_results).to_pandas()
+        return self.VectorDB.text_search(query, n_results)
 
     def vector_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
         """Search the LanceDB for the query"""
-        query_embedding = self.vector_model.encode([query])[0]
-        return self.vector_db.search(query_embedding).select(["id", "text"]).limit(n_results).to_pandas()
+        return self.VectorDB.vector_search(query, n_results)

--- a/discovery_utils/getters/crunchbase.py
+++ b/discovery_utils/getters/crunchbase.py
@@ -7,8 +7,13 @@ import logging
 import os
 import re
 
+from pathlib import Path
+
 import pandas as pd
 
+from sentence_transformers import SentenceTransformer
+
+from discovery_utils.utils import embeddings
 from discovery_utils.utils import s3
 
 
@@ -22,7 +27,7 @@ logger = logging.getLogger(__name__)
 class CrunchbaseGetter:
     """Class to get Crunchbase data from S3"""
 
-    def __init__(self, use_latest_version: bool = True, data_version: str = None) -> None:
+    def __init__(self, use_latest_version: bool = True, data_version: str = None, vector_db_path: Path = None) -> None:
         """Initialise CrunchbaseGetter
 
         Args:
@@ -58,6 +63,14 @@ class CrunchbaseGetter:
         self._organisation_categories = None
         self._category_groups = None
         self._group_to_categories = None
+        # Vector DB
+        self._vector_db_path = vector_db_path
+        self._vector_db_name = "crunchbase-lancedb"
+        self._vector_db_table_name = "company_embeddings"
+        self._vector_model_name = "all-MiniLM-L6-v2"
+        self._vector_model = None
+        self._vector_db_connection = None
+        self._vector_db = None
 
     def _get_latest_data_version(self) -> str:
         """Find the latest Crunchbase version based on S3 folder timestamps."""
@@ -287,3 +300,34 @@ class CrunchbaseGetter:
                 .sort_values(["group", "category"])
             )[["group", "category"]]
         return self._group_to_categories
+
+    @property
+    def vector_db(self) -> embeddings.LanceDBConnection:
+        """Get the LanceDB connection"""
+        if self._vector_db is None:
+            self._vector_db_connection = embeddings.load_lancedb_embeddings(
+                self._vector_db_name, local_path=self._vector_db_path
+            )
+            self._vector_db = self._vector_db_connection.open_table(self._vector_db_table_name)
+            # Enable full text searches
+            try:
+                self._vector_db.create_fts_index("text")
+            except Exception as e:
+                logging.error(f"Error creating FTS index: {str(e)}")
+        return self._vector_db
+
+    @property
+    def vector_model(self) -> SentenceTransformer:
+        """Get the sentence transformer model"""
+        if self._vector_model is None:
+            self._vector_model = SentenceTransformer(self._vector_model_name)
+        return self._vector_model
+
+    def text_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
+        """Search the LanceDB for the query"""
+        return self.vector_db.search(query, query_type="fts").select(["id", "text"]).limit(n_results).to_pandas()
+
+    def vector_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
+        """Search the LanceDB for the query"""
+        query_embedding = self.vector_model.encode([query])[0]
+        return self.vector_db.search(query_embedding).select(["id", "text"]).limit(n_results).to_pandas()

--- a/discovery_utils/getters/gtr.py
+++ b/discovery_utils/getters/gtr.py
@@ -8,11 +8,15 @@ import logging
 import os
 import re
 
+from pathlib import Path
 from typing import Dict
 from typing import List
 
 import pandas as pd
 
+from sentence_transformers import SentenceTransformer
+
+from discovery_utils.utils import embeddings
 from discovery_utils.utils import s3
 
 
@@ -26,7 +30,7 @@ logger = logging.getLogger(__name__)
 class GtrGetter:
     """Class to get Gateway to Research data from S3"""
 
-    def __init__(self, use_latest_version: bool = True, data_version: str = None) -> None:
+    def __init__(self, use_latest_version: bool = True, data_version: str = None, vector_db_path: Path = None) -> None:
         """Initialise GtrGetter
 
         Args:
@@ -50,6 +54,14 @@ class GtrGetter:
         self._projects_organisations = None
         self._persons_organisations = None
         self._default_text_fields = ["title", "abstractText", "techAbstractText", "potentialImpact"]
+        # Vector DB
+        self._vector_db_path = vector_db_path
+        self._vector_db_name = "gtr-lancedb"
+        self._vector_db_table_name = "project_embeddings"
+        self._vector_model_name = "all-MiniLM-L6-v2"
+        self._vector_model = None
+        self._vector_db_connection = None
+        self._vector_db = None
 
     def _get_latest_data_version(self) -> str:
         """Find the latest version based on S3 folder timestamps."""
@@ -336,3 +348,34 @@ class GtrGetter:
             .assign(text=lambda df: df.text.apply(lambda x: re.sub(boilerplate_empty_text, "", x)))
             .drop(columns=text_fields)
         )
+
+    @property
+    def vector_db(self) -> embeddings.LanceDBConnection:
+        """Get the LanceDB connection"""
+        if self._vector_db is None:
+            self._vector_db_connection = embeddings.load_lancedb_embeddings(
+                self._vector_db_name, local_path=self._vector_db_path
+            )
+            self._vector_db = self._vector_db_connection.open_table(self._vector_db_table_name)
+            # Enable full text searches
+            try:
+                self._vector_db.create_fts_index("text")
+            except Exception as e:
+                logging.error(f"Error creating FTS index: {str(e)}")
+        return self._vector_db
+
+    @property
+    def vector_model(self) -> SentenceTransformer:
+        """Get the sentence transformer model"""
+        if self._vector_model is None:
+            self._vector_model = SentenceTransformer(self._vector_model_name)
+        return self._vector_model
+
+    def text_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
+        """Search the LanceDB for the query"""
+        return self.vector_db.search(query, query_type="fts").select(["id", "text"]).limit(n_results).to_pandas()
+
+    def vector_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
+        """Search the LanceDB for the query"""
+        query_embedding = self.vector_model.encode([query])[0]
+        return self.vector_db.search(query_embedding).select(["id", "text"]).limit(n_results).to_pandas()

--- a/discovery_utils/getters/gtr.py
+++ b/discovery_utils/getters/gtr.py
@@ -14,8 +14,6 @@ from typing import List
 
 import pandas as pd
 
-from sentence_transformers import SentenceTransformer
-
 from discovery_utils.utils import embeddings
 from discovery_utils.utils import s3
 
@@ -55,13 +53,9 @@ class GtrGetter:
         self._persons_organisations = None
         self._default_text_fields = ["title", "abstractText", "techAbstractText", "potentialImpact"]
         # Vector DB
-        self._vector_db_path = vector_db_path
-        self._vector_db_name = "gtr-lancedb"
-        self._vector_db_table_name = "project_embeddings"
-        self._vector_model_name = "all-MiniLM-L6-v2"
-        self._vector_model = None
-        self._vector_db_connection = None
-        self._vector_db = None
+        self.VectorDB = embeddings.VectorDB(
+            db_path=vector_db_path, db_name="gtr-lancedb", table_name="project_embeddings", model="all-MiniLM-L6-v2"
+        )
 
     def _get_latest_data_version(self) -> str:
         """Find the latest version based on S3 folder timestamps."""
@@ -352,30 +346,12 @@ class GtrGetter:
     @property
     def vector_db(self) -> embeddings.LanceDBConnection:
         """Get the LanceDB connection"""
-        if self._vector_db is None:
-            self._vector_db_connection = embeddings.load_lancedb_embeddings(
-                self._vector_db_name, local_path=self._vector_db_path
-            )
-            self._vector_db = self._vector_db_connection.open_table(self._vector_db_table_name)
-            # Enable full text searches
-            try:
-                self._vector_db.create_fts_index("text")
-            except Exception as e:
-                logging.error(f"Error creating FTS index: {str(e)}")
-        return self._vector_db
-
-    @property
-    def vector_model(self) -> SentenceTransformer:
-        """Get the sentence transformer model"""
-        if self._vector_model is None:
-            self._vector_model = SentenceTransformer(self._vector_model_name)
-        return self._vector_model
+        return self.VectorDB.vector_db
 
     def text_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
         """Search the LanceDB for the query"""
-        return self.vector_db.search(query, query_type="fts").select(["id", "text"]).limit(n_results).to_pandas()
+        return self.VectorDB.text_search(query, n_results)
 
     def vector_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
         """Search the LanceDB for the query"""
-        query_embedding = self.vector_model.encode([query])[0]
-        return self.vector_db.search(query_embedding).select(["id", "text"]).limit(n_results).to_pandas()
+        return self.VectorDB.vector_search(query, n_results)

--- a/discovery_utils/utils/embeddings.py
+++ b/discovery_utils/utils/embeddings.py
@@ -90,3 +90,50 @@ def download_lancedb_embeddings(
 
         shutil.unpack_archive(local_key, str(_local_path))
         logging.info(f"Unzipped {local_key} to {_local_path}")
+
+
+class VectorDB:
+    """Class to handle the LanceDB connection and search"""
+
+    def __init__(self, db_path: Path, db_name: str, table_name: str, model: str) -> None:
+        """Initialise the VectorDB class
+
+        Args:
+            vector_db_path (Path): Path to the local LanceDB embeddings
+        """
+        self._vector_db_path = db_path
+        self._vector_db_name = db_name
+        self._vector_db_table_name = table_name
+        self._vector_model_name = model
+        self._vector_model = None
+        self._vector_db_connection = None
+        self._vector_db = None
+
+    @property
+    def vector_db(self) -> LanceDBConnection:
+        """Get the LanceDB connection"""
+        if self._vector_db is None:
+            self._vector_db_connection = load_lancedb_embeddings(self._vector_db_name, local_path=self._vector_db_path)
+            self._vector_db = self._vector_db_connection.open_table(self._vector_db_table_name)
+            # Enable full text searches
+            try:
+                self._vector_db.create_fts_index("text")
+            except Exception as e:
+                logging.error(f"Error creating FTS index: {str(e)}")
+        return self._vector_db
+
+    @property
+    def vector_model(self) -> SentenceTransformer:
+        """Get the sentence transformer model"""
+        if self._vector_model is None:
+            self._vector_model = SentenceTransformer(self._vector_model_name)
+        return self._vector_model
+
+    def text_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
+        """Search the LanceDB for the query"""
+        return self.vector_db.search(query, query_type="fts").select(["id", "text"]).limit(n_results).to_pandas()
+
+    def vector_search(self, query: str, n_results: int = 10) -> pd.DataFrame:
+        """Search the LanceDB for the query"""
+        query_embedding = self.vector_model.encode([query])[0]
+        return self.vector_db.search(query_embedding).select(["id", "text"]).limit(n_results).to_pandas()

--- a/discovery_utils/utils/embeddings.py
+++ b/discovery_utils/utils/embeddings.py
@@ -38,9 +38,7 @@ def add_embeddings(df: pd.DataFrame, text_col: str = "text", model_name: str = "
     return df
 
 
-def load_lancedb_embeddings(
-    embeddings: str,
-) -> LanceDBConnection:
+def load_lancedb_embeddings(embeddings: str, local_path: str = LOCAL_VECTOR_DB_PATH) -> LanceDBConnection:
     """
     Load the lancedb embeddings
 
@@ -48,8 +46,10 @@ def load_lancedb_embeddings(
         embeddings (str): Name of the embeddings to load
     """
     # Load the lanceDB
-    download_lancedb_embeddings(embeddings)
-    db = lancedb.connect(f"{LOCAL_VECTOR_DB_PATH}/{embeddings}")
+    if local_path is None:
+        raise ValueError("Vector database path is not set")
+    download_lancedb_embeddings(embeddings, overwrite=False, local_path=local_path)
+    db = lancedb.connect(f"{local_path}/{embeddings}")
     logging.info(f"Connected with database {embeddings}. Available tables: {db.table_names()}")
     return db
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pyalex = "^0.15.1"
 lxml = ">=5.3.0"
 huggingface-hub = "^0.25.1"
 lancedb = "^0.14.0"
+tantivy = "^0.22.0"
 
 [tool.poetry.group.evals]
 optional = true


### PR DESCRIPTION
Closes #61 

Adds text and vector search utils for GtR and Crunchbase data getters, utilising the LanceDB databases.

I've also added more info [in the Wiki](https://github.com/nestauk/discovery_utils/wiki/Vector-databases).

One question is if there's a good way to reduce code duplication, as the code for both datasets is the same. Maybe I should create a separate vector db class with the wrappers, that gets imported in the getters? @sqr00t, @shabrf maybe you have opinions on this?

